### PR TITLE
#98 Drop actions endpoint if stateless

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,14 +1,12 @@
-.githooks @asynchroza @SuelaCark @nikolayninov
-
 .github/workflows @asynchroza
 
 .vscode @asynchroza
 
 data @asynchroza
 
-packages/web @SuelaCark @Aleks1908 @asynchroza @nikolayninov @DemonHashira
+packages/web @SuelaCark @Aleks1908 @asynchroza @nikolayninov @DemonHashira @r-mishev
 
-packages/api @nikolayninov @IvanObreshkov @asynchroza @peti-krl
+packages/api @nikolayninov @IvanObreshkov @asynchroza
 
 **/Dockerfile @asynchroza
 
@@ -16,7 +14,7 @@ packages/api @nikolayninov @IvanObreshkov @asynchroza @peti-krl
 
 manage_app.py @asynchroza
 
-**/*.sh @asynchroza @SuelaCark @r-mishev
+**/*.sh @asynchroza @SuelaCark @r-mishev @IvanObreshkov
 
 Makefile @asynchroza
 

--- a/packages/web/src/App.js
+++ b/packages/web/src/App.js
@@ -42,10 +42,7 @@ import AddNoTeamParticipant from './components/admin_page/hackathon/hackathon_no
 
 function App() {
     document.addEventListener('locationChange', handleUrlDependantStyling);
-    window.addEventListener('load', () => {
-        handleUrlDependantStyling();
-    });
-
+    window.addEventListener('load', handleUrlDependantStyling);
     useEffect(handleUrlDependantStyling, []);
 
     goBackIfActionsAreStateless();

--- a/packages/web/src/App.js
+++ b/packages/web/src/App.js
@@ -31,7 +31,7 @@ import TeamActions from './components/admin_page/hackathon/hackathon_teams/actio
 
 import S3Panel from './components/admin_page/s3_page/s3_landing';
 import { RenderStorageObjects } from './components/admin_page/s3_page/render_objects';
-import { handleUrlDependantStyling } from './Global';
+import { goBackIfActionsAreStateless, handleUrlDependantStyling } from './Global';
 import { FEATURE_SWITCHES } from './feature_switches';
 import TeamMemberActions from './components/admin_page/hackathon/hackathon_team_members/single_team_member.jsx';
 import AddTeamMember from './components/admin_page/hackathon/hackathon_team_members/new_member';
@@ -42,126 +42,57 @@ import AddNoTeamParticipant from './components/admin_page/hackathon/hackathon_no
 
 function App() {
     document.addEventListener('locationChange', handleUrlDependantStyling);
-    window.addEventListener('load', handleUrlDependantStyling);
+    window.addEventListener('load', () => {
+        handleUrlDependantStyling();
+    });
+
     useEffect(handleUrlDependantStyling, []);
+
+    goBackIfActionsAreStateless();
 
     return (
         <Routes>
             <Route path="/" element={<LandingHome />} />
             <Route path="/admin" element={<LandingAdminPage />} />
             <Route path="/admin/dashboard" element={<Dashboard />} />
-            <Route
-                path="/admin/dashboard/members"
-                element={<RenderMembers />}
-            />
-            <Route
-                path="/admin/dashboard/members/actions"
-                element={<MemberActions />}
-            />
-            <Route
-                path="/admin/dashboard/members/add"
-                element={<AddMember />}
-            />
+            <Route path="/admin/dashboard/members" element={<RenderMembers />} />
+            <Route path="/admin/dashboard/members/actions" element={<MemberActions />} />
+            <Route path="/admin/dashboard/members/add" element={<AddMember />} />
             <Route path="/admin/dashboard/jobs" element={<RenderJobs />} />
-            <Route
-                path="/admin/dashboard/jobs/actions"
-                element={<JobActions />}
-            />
-            <Route
-                path="/admin/dashboard/mentors"
-                element={<RenderMentors />}
-            />
-            <Route
-                path="/admin/dashboard/mentors/add"
-                element={<AddMentors />}
-            />
-            <Route
-                path="/admin/dashboard/mentors/actions"
-                element={<MentorsActions />}
-            />
+            <Route path="/admin/dashboard/jobs/actions" element={<JobActions />} />
+            <Route path="/admin/dashboard/mentors" element={<RenderMentors />} />
+            <Route path="/admin/dashboard/mentors/add" element={<AddMentors />} />
+            <Route path="/admin/dashboard/mentors/actions" element={<MentorsActions />} />
             <Route path="/admin/dashboard/jury" element={<RenderJury />} />
             <Route path="/admin/dashboard/jury/add" element={<AddJury />} />
-            <Route
-                path="/admin/dashboard/jury/actions"
-                element={<JuryActions />}
-            />
-            <Route
-                path="/admin/dashboard/sponsors"
-                element={<RenderSponsors />}
-            />
-            <Route
-                path="/admin/dashboard/sponsors/add"
-                element={<AddSponsors />}
-            />
-            <Route
-                path="/admin/dashboard/sponsors/actions"
-                element={<SponsorsActions />}
-            />
-            <Route
-                path="/admin/dashboard/partners"
-                element={<RenderPartners />}
-            />
-            <Route
-                path="/admin/dashboard/partners/add"
-                element={<AddPartners />}
-            />
-            <Route
-                path="/admin/dashboard/partners/actions"
-                element={<PartnersActions />}
-            />
-            <Route
-                path="/admin/dashboard/hackathon/teams"
-                element={<RenderTeams />}
-            />
-            <Route
-                path="/admin/dashboard/hackathon/teams/members"
-                element={<RenderTeamMembers />}
-            />
-            <Route
-                path="/admin/dashboard/hackathon/teams/members/actions"
-                element={<TeamMemberActions />}
-            />
-            <Route
-                path="/admin/dashboard/hackathon/teams/members/add"
-                element={<AddTeamMember />}
-            />
-            <Route
-                path="/admin/dashboard/hackathon/teams/add"
-                element={<AddNewTeam />}
-            />
-            <Route
-                path="/admin/dashboard/hackathon/noteamparticipants/add"
-                element={<AddNoTeamParticipant />}
-            />
-            <Route
-                path="/admin/dashboard/hackathon/teams/actions"
-                element={<TeamActions />}
-            />
-            <Route
-                path="/admin/dashboard/hackathon/noteamparticipants"
-                element={<RenderNoTeamParticipants />}
-            />
+            <Route path="/admin/dashboard/jury/actions" element={<JuryActions />} />
+            <Route path="/admin/dashboard/sponsors" element={<RenderSponsors />} />
+            <Route path="/admin/dashboard/sponsors/add" element={<AddSponsors />} />
+            <Route path="/admin/dashboard/sponsors/actions" element={<SponsorsActions />} />
+            <Route path="/admin/dashboard/partners" element={<RenderPartners />} />
+            <Route path="/admin/dashboard/partners/add" element={<AddPartners />} />
+            <Route path="/admin/dashboard/partners/actions" element={<PartnersActions />} />
+            <Route path="/admin/dashboard/hackathon/teams" element={<RenderTeams />} />
+            <Route path="/admin/dashboard/hackathon/teams/members" element={<RenderTeamMembers />} />
+            <Route path="/admin/dashboard/hackathon/teams/members/actions" element={<TeamMemberActions />} />
+            <Route path="/admin/dashboard/hackathon/teams/members/add" element={<AddTeamMember />} />
+            <Route path="/admin/dashboard/hackathon/teams/add" element={<AddNewTeam />} />
+            <Route path="/admin/dashboard/hackathon/noteamparticipants/add" element={<AddNoTeamParticipant />} />
+            <Route path="/admin/dashboard/hackathon/teams/actions" element={<TeamActions />} />
+            <Route path="/admin/dashboard/hackathon/noteamparticipants" element={<RenderNoTeamParticipants />} />
             <Route
                 path="/admin/dashboard/hackathon/noteamparticipants/actions"
                 element={<NoTeamParticipantsActions />}
             />
             <Route path="/admin/dashboard/jobs" element={<RenderJobs />} />
-            <Route
-                path="/admin/dashboard/jobs/actions"
-                element={<JobActions />}
-            />
+            <Route path="/admin/dashboard/jobs/actions" element={<JobActions />} />
             <Route path="/admin/dashboard/jobs/add" element={<AddJobs />} />
 
             <Route path="/hackaubg" element={<HackAUBG />} />
-            {FEATURE_SWITCHES.jobs ? (
-                <Route path="/jobs" element={<JobsSection />} />
-            ) : null}
+            {FEATURE_SWITCHES.jobs ? <Route path="/jobs" element={<JobsSection />} /> : null}
             <Route path="/*" element={<NotFound />} />
             <Route path="/admin/dashboard/s3" element={<S3Panel />} />
-            <Route
-                path="/admin/dashboard/s3/objects"
-                element={<RenderStorageObjects />}
-            />
+            <Route path="/admin/dashboard/s3/objects" element={<RenderStorageObjects />} />
         </Routes>
     );
 }

--- a/packages/web/src/Global.js
+++ b/packages/web/src/Global.js
@@ -1,10 +1,12 @@
 import axios from 'axios';
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
+// TODO: Deprecate this - it will be handled by a request to python api
 // eslint-disable-next-line
 const objUploaderURL = process.env.REACT_APP_OBJ_UPLOADER_URL;
 
+// TODO: Deprecate this - it will be abstracted in python api
 // eslint-disable-next-line
 const gcpToken = process.env.REACT_APP_GCP_TOKEN;
 
@@ -21,13 +23,13 @@ const checkBrowserValid = () => {
         'Chrome',
         'Safari',
         'Firefox',
-        'Chromium'
+        'Chromium',
         // No IE
     ];
 
     let isValid = false;
 
-    browsers.forEach((x) => {
+    browsers.forEach(x => {
         if (navigator.userAgent.indexOf(x) != -1) {
             isValid = true;
         }
@@ -42,14 +44,14 @@ const Validate = () => {
         axios({
             method: 'post',
             url: url + '/api/validate',
-            headers: { 'BEARER-TOKEN': localStorage.getItem('auth_token') }
+            headers: { 'BEARER-TOKEN': localStorage.getItem('auth_token') },
         })
             // eslint-disable-next-line no-unused-vars
-            .then((res) => {
+            .then(() => {
                 setValidated(true);
             })
             // eslint-disable-next-line no-unused-vars
-            .catch((err) => {
+            .catch(() => {
                 setValidated(false);
             });
     }, []);
@@ -61,14 +63,12 @@ const checkHashAndScroll = () => {
     let hasHash = !!location.hash;
     if (hasHash) {
         setTimeout(() => {
-            document
-                .getElementById(location.hash.replace('#', ''))
-                .scrollIntoView();
+            document.getElementById(location.hash.replace('#', '')).scrollIntoView();
         }, 600);
     }
 };
 
-const openNewTab = (url) => {
+const openNewTab = url => {
     window.open(url, '_blank');
 };
 
@@ -106,7 +106,7 @@ const handleUrlDependantStyling = () => {
 
 const History = {
     navigate: null,
-    push: (page, ...rest) => History.navigate(page, ...rest)
+    push: (page, ...rest) => History.navigate(page, ...rest),
 };
 
 const NavigateSetter = () => {
@@ -115,10 +115,23 @@ const NavigateSetter = () => {
     return null;
 };
 
-const navigateTo = (endpoint) => {
+const navigateTo = endpoint => {
     History.navigate(endpoint);
 
     document.dispatchEvent(new Event('locationChange'));
+};
+
+const goBackIfActionsAreStateless = () => {
+    /**
+     * @description Fix for https://github.com/AUBGTheHUB/monolith/issues/98
+     */
+
+    if (location.href.includes('actions')) {
+        const currentLocation = useLocation();
+        if (!currentLocation.state) {
+            location.href = location.href.replace(/\/[^/]+$/, '');
+        }
+    }
 };
 
 export {
@@ -130,7 +143,8 @@ export {
     NavigateSetter,
     navigateTo,
     objUploaderURL,
-    gcpToken
+    gcpToken,
+    goBackIfActionsAreStateless,
 };
 export default Validate;
 

--- a/packages/web/src/components/admin_page/dash_page.jsx
+++ b/packages/web/src/components/admin_page/dash_page.jsx
@@ -9,7 +9,7 @@ const Dash = () => {
         return (
             <div className="dash">
                 <div className="dash-box">
-                    {landingEntries.map((entry) => (
+                    {landingEntries.map(entry => (
                         <LandingCard
                             text={entry.text}
                             url={entry.url}


### PR DESCRIPTION
resolves #98 

## How to verify:

Manually append `/actions` to an endpoint of section you've chosen from the dashboard.
For example `partners` which lives on `/admin/dashboard/partners`
<img width="606" alt="image" src="https://github.com/AUBGTheHUB/monolith/assets/104720011/64632c26-c39d-4d58-9ff7-1fc5a57bb250">

Try to access `/admin/dashboard/partners/actions` and you should be returned back to the previous page no matter whether you do it in the same tab or in a new one. 
