### PR TITLE
#488 Fix upsert request in shortener to not allow bad endpoints

### DIFF
--- a/packages/py-api/py_api/controllers/url_shortener_controller.py
+++ b/packages/py-api/py_api/controllers/url_shortener_controller.py
@@ -3,6 +3,7 @@ from typing import Dict, List
 from fastapi.responses import JSONResponse
 from py_api.database import su_col
 from py_api.models import ShortenedURL
+from py_api.utilities.parsers import has_prohibited_characters
 
 
 class UrlShortenerController:
@@ -25,8 +26,12 @@ class UrlShortenerController:
             return JSONResponse(content={"message": "Endpoint wasn't found!"}, status_code=404)
 
     @classmethod
-    def upsert_shortened_url(cls, body: ShortenedURL) -> Dict[str, str]:
+    def upsert_shortened_url(cls, body: ShortenedURL) -> Dict[str, str] | JSONResponse:
         dumped_body = body.model_dump()
+
+        if has_prohibited_characters(dumped_body["endpoint"], "/:!@#$%\\[]^*()_-+{}=?.,§~`"):
+            return JSONResponse(content={"message": "Provided endpoint includes a probited characters - /:!@#$%\\[]^*()_-+{}=?.,§~`"}, status_code=400)
+
         su_col.find_one_and_update(
             filter={"endpoint": dumped_body["endpoint"]},
             update={"$set": dumped_body},

--- a/packages/py-api/py_api/controllers/url_shortener_controller.py
+++ b/packages/py-api/py_api/controllers/url_shortener_controller.py
@@ -28,9 +28,10 @@ class UrlShortenerController:
     @classmethod
     def upsert_shortened_url(cls, body: ShortenedURL) -> Dict[str, str] | JSONResponse:
         dumped_body = body.model_dump()
+        prohibited_chars = "'\";/:!@#$%\\[]^*()_-+{}=?.,§~`"
 
-        if has_prohibited_characters(dumped_body["endpoint"], "/:!@#$%\\[]^*()_-+{}=?.,§~`"):
-            return JSONResponse(content={"message": "Provided endpoint includes a probited characters - /:!@#$%\\[]^*()_-+{}=?.,§~`"}, status_code=400)
+        if has_prohibited_characters(dumped_body["endpoint"], prohibited_chars):
+            return JSONResponse(content={"message": f"Provided endpoint includes a probited character - {prohibited_chars}"}, status_code=400)
 
         su_col.find_one_and_update(
             filter={"endpoint": dumped_body["endpoint"]},

--- a/packages/py-api/py_api/utilities/parsers.py
+++ b/packages/py-api/py_api/utilities/parsers.py
@@ -1,4 +1,5 @@
 from json import loads
+from re import escape, search
 from typing import Any, Callable, Dict
 
 
@@ -17,3 +18,8 @@ def eval_bool(bl: str | bool) -> bool:
             return True
         else:
             return False
+
+
+def has_prohibited_characters(input_string: str, prohibited_pattern: str) -> bool:
+    prohibited_pattern = f"[{escape(prohibited_pattern)}]"
+    return bool(search(prohibited_pattern, input_string))


### PR DESCRIPTION
Do not allow the creation of invalid shortened urls which result in 404 when trying to be reached, updated or removed.

## How to verify
* Try to create a bad endpoint including any one of the prohibited characters. You should get a 400 response or a message on the frontend saying that your input includes a prohibited character.
* Try to break it

resolves #488 