### PR TITLE
#491 Remove the need for verification requests to Golang API when running locally

### DIFF
--- a/packages/py-api/py_api/environment.py
+++ b/packages/py-api/py_api/environment.py
@@ -8,3 +8,5 @@ load_dotenv()
 MONGO_URI = getenv("MONGOURI", "")
 
 IS_OFFLINE = eval_bool(getenv("IS_OFFLINE", False))
+
+OFFLINE_TOKEN = "OFFLINE_TOKEN"

--- a/packages/py-api/py_api/utilities/parsers.py
+++ b/packages/py-api/py_api/utilities/parsers.py
@@ -1,6 +1,6 @@
 from json import loads
 from re import escape, search
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, List, Self
 
 
 async def parse_request_body(body: Callable[..., bytes]) -> Dict[Any, Any]:
@@ -23,3 +23,9 @@ def eval_bool(bl: str | bool) -> bool:
 def has_prohibited_characters(input_string: str, prohibited_pattern: str) -> bool:
     prohibited_pattern = f"[{escape(prohibited_pattern)}]"
     return bool(search(prohibited_pattern, input_string))
+
+
+class AttrDict(dict[Any, Any]):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super(AttrDict, self).__init__(*args, **kwargs)
+        self.__dict__ = self


### PR DESCRIPTION
Bypass authentication request to Golang API by comparing received BEARER-TOKEN to OFFLINE_TOKEN when running the Python API locally.

resolves #491 

## How to verify:

- [ ] Add a logger in the conditional statement for checking the offline environment in the authentication middleware
- [ ] Check if log message gets displayed and you can run all the requests that you need when passing the correct BEARER-TOKEN

