### PR TITLE
#498 Add basic request analytics

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,6 +3,7 @@ MONGOURI=
 
 ## API - ENVIRONMENT STATE (check readme for BEARER-TOKEN)
 IS_OFFLINE=true
+IS_PROD=false
 IS_TEST=false  # this takes precedence over IS_OFFLINE
 
 ## OBJECT UPLOADER

--- a/packages/py-api/py_api/environment.py
+++ b/packages/py-api/py_api/environment.py
@@ -8,5 +8,6 @@ load_dotenv()
 MONGO_URI = getenv("MONGOURI", "")
 
 IS_OFFLINE = eval_bool(getenv("IS_OFFLINE", False))
+IS_PROD = eval_bool(getenv("IS_PROD", False))
 
 OFFLINE_TOKEN = "OFFLINE_TOKEN"

--- a/packages/py-api/py_api/main.py
+++ b/packages/py-api/py_api/main.py
@@ -1,7 +1,7 @@
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from py_api.middleware import AuthMiddleware, ExceptionHandler
+from py_api.middleware import Middleware
 from py_api.routes import Routes
 from py_api.utilities.logging import get_log_config
 from uvicorn import run
@@ -12,8 +12,7 @@ main_app = FastAPI()
 app = FastAPI()
 
 Routes.bind(app)
-AuthMiddleware.bind(app)
-ExceptionHandler.bind(app)
+Middleware.bind(app)
 
 app.add_middleware(
     CORSMiddleware,

--- a/packages/py-api/py_api/middleware/__init__.py
+++ b/packages/py-api/py_api/middleware/__init__.py
@@ -1,7 +1,5 @@
-from py_api.middleware.auth import AuthMiddleware
-from py_api.middleware.exception_handler import ExceptionHandler
+from py_api.middleware.middleware import Middleware
 
 __all__ = [
-    "AuthMiddleware",
-    "ExceptionHandler",
+    "Middleware",
 ]

--- a/packages/py-api/py_api/middleware/analytics.py
+++ b/packages/py-api/py_api/middleware/analytics.py
@@ -45,7 +45,7 @@ class AnalyticsMiddleware:
     @staticmethod
     def get_country_and_city_from_ip(ip_address: str) -> Tuple[str, str]:
         response = get(
-            "https://geolocation-db.com/json/{ip_address}&position=false",
+            f"https://geolocation-db.com/json/{ip_address}",
         ).json()
         return response["country_name"], response["city"]
 

--- a/packages/py-api/py_api/middleware/analytics.py
+++ b/packages/py-api/py_api/middleware/analytics.py
@@ -45,12 +45,12 @@ class AnalyticsMiddleware:
         ).json()
         return (response["country_name"], response["city"])
 
-    def create_update_operation(common_locations: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    def create_update_operation(locations: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
         update_operation: Dict[str, Dict[str, Any]] = {
             "$set": {},
         }
 
-        for key, item in common_locations.items():
+        for key, item in locations.items():
             update_operation["$set"][key] = item
 
         return update_operation
@@ -59,18 +59,18 @@ class AnalyticsMiddleware:
         if not analytics:
             analytics = {
                 "total_requests": 0,
-                "common_locations": {},
+                "locations": {},
             }
 
         analytics["total_requests"] = analytics["total_requests"] + 1
 
-        if country_dict := analytics["common_locations"].get(country):
+        if country_dict := analytics["locations"].get(country):
             if current_count := country_dict.get(city):
-                analytics["common_locations"][country][city] = current_count + 1
+                analytics["locations"][country][city] = current_count + 1
             else:
-                analytics["common_locations"][country][city] = 1
+                analytics["locations"][country][city] = 1
         else:
-            analytics["common_locations"][country] = {
+            analytics["locations"][country] = {
                 city: 1,
             }
 

--- a/packages/py-api/py_api/middleware/analytics.py
+++ b/packages/py-api/py_api/middleware/analytics.py
@@ -1,0 +1,72 @@
+from logging import getLogger
+from typing import Any, Callable, Dict, Tuple
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from py_api.database import db
+from requests import get
+from starlette.background import BackgroundTask
+
+logger = getLogger("analytics")
+
+
+class AnalyticsMiddleware:
+    an_col = db.analytics
+
+    def __init__(self, app: FastAPI) -> None:
+        @app.middleware('http')
+        async def run_analytics(request: Request, call_next: Callable[[Any], Any]) -> JSONResponse:
+            response = await call_next(request)
+            response.background = BackgroundTask(self.update_entries, request)
+            return response
+
+    @classmethod
+    async def update_entries(cls, request: Request) -> None:
+        projection = {"_id": 0}
+        analytics = cls.an_col.find_one({}, projection)
+        country, city = cls.get_country_and_city_from_ip(request.client)
+
+        analytics = cls.update_analytics(analytics, country, city)
+
+        update_operation = cls.create_update_operation(analytics)
+        status = cls.an_col.update_one({}, update_operation, upsert=True)
+
+        if status.modified_count != 1 and not status.acknowledged:
+            logger.error("Couldn't update analytics")
+
+    def get_country_and_city_from_ip(ip_address: str) -> Tuple[str, str]:
+        response = get(
+            "https://geolocation-db.com/json/{ip_address}&position=false",
+        ).json()
+        return (response["country_name"], response["city"])
+
+    def create_update_operation(common_locations: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+        update_operation: Dict[str, Dict[str, Any]] = {
+            "$set": {},
+        }
+
+        for key, item in common_locations.items():
+            update_operation["$set"][key] = item
+
+        return update_operation
+
+    def update_analytics(analytics: Dict[str, Any] | None, country: str, city: str) -> Dict[str, Any]:
+        if not analytics:
+            analytics = {
+                "total_requests": 0,
+                "common_locations": {},
+            }
+
+        analytics["total_requests"] = analytics["total_requests"] + 1
+
+        if country_dict := analytics["common_locations"].get(country):
+            if current_count := country_dict.get(city):
+                analytics["common_locations"][country][city] = current_count + 1
+            else:
+                analytics["common_locations"][country][city] = 1
+        else:
+            analytics["common_locations"][country] = {
+                city: 1,
+            }
+
+        return analytics

--- a/packages/py-api/py_api/middleware/analytics.py
+++ b/packages/py-api/py_api/middleware/analytics.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Dict, Tuple
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from py_api.database import db
+from py_api.environment import IS_PROD
 from requests import get
 from starlette.background import BackgroundTask
 
@@ -17,7 +18,11 @@ class AnalyticsMiddleware:
         @app.middleware('http')
         async def run_analytics(request: Request, call_next: Callable[[Any], Any]) -> JSONResponse:
             response = await call_next(request)
-            response.background = BackgroundTask(self.update_entries, request)
+            if IS_PROD:
+                response.background = BackgroundTask(
+                    self.update_entries, request,
+                )
+
             return response
 
     @classmethod

--- a/packages/py-api/py_api/middleware/analytics.py
+++ b/packages/py-api/py_api/middleware/analytics.py
@@ -27,6 +27,7 @@ class AnalyticsMiddleware:
 
     @classmethod
     async def update_entries(cls, request: Request) -> None:
+        country, city = None, None
         projection = {"_id": 0}
         analytics = cls.an_col.find_one({}, projection)
 
@@ -57,7 +58,7 @@ class AnalyticsMiddleware:
 
         return update_operation
 
-    def update_analytics(analytics: Dict[str, Any] | None, country: str | None = None, city: str | None = None) -> Dict[str, Any]:
+    def update_analytics(analytics: Dict[str, Any] | None, country: str | None, city: str | None) -> Dict[str, Any]:
         if not analytics:
             analytics = {
                 "total_requests": 0,
@@ -66,7 +67,7 @@ class AnalyticsMiddleware:
 
         analytics["total_requests"] = analytics["total_requests"] + 1
 
-        if not country and not city:
+        if not country or not city:
             return analytics
 
         if country_dict := analytics["locations"].get(country):

--- a/packages/py-api/py_api/middleware/analytics.py
+++ b/packages/py-api/py_api/middleware/analytics.py
@@ -42,12 +42,14 @@ class AnalyticsMiddleware:
         if status.modified_count != 1 and not status.acknowledged:
             logger.error("Couldn't update analytics")
 
+    @staticmethod
     def get_country_and_city_from_ip(ip_address: str) -> Tuple[str, str]:
         response = get(
             "https://geolocation-db.com/json/{ip_address}&position=false",
         ).json()
         return response["country_name"], response["city"]
 
+    @staticmethod
     def create_update_operation(locations: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
         update_operation: Dict[str, Dict[str, Any]] = {
             "$set": {},
@@ -58,6 +60,7 @@ class AnalyticsMiddleware:
 
         return update_operation
 
+    @staticmethod
     def update_analytics(analytics: Dict[str, Any] | None, country: str | None, city: str | None) -> Dict[str, Any]:
         if not analytics:
             analytics = {

--- a/packages/py-api/py_api/middleware/auth.py
+++ b/packages/py-api/py_api/middleware/auth.py
@@ -22,17 +22,15 @@ class AuthMiddleware:
         "/health": ["GET"], "/routes": ["GET"], "/fswitches": ["GET"],
     }
 
-    @classmethod
-    def bind(cls, app: FastAPI) -> None:
-
+    def __init__(self, app: FastAPI) -> None:
         @app.middleware("http")
         async def verify_request(request: Request, call_next: Callable[[Any], Any]) -> JSONResponse:
-            endpoint, is_bypassed = cls._check_bypassed_endpoint(request.url)
+            endpoint, is_bypassed = self._check_bypassed_endpoint(request.url)
 
             if not is_bypassed or (
                     # autopep8: off
-                    request.method not in cls._BYPASSED_ENDPOINTS[endpoint]  # type: ignore
-                    and cls._BYPASSED_ENDPOINTS[endpoint][0] != "*"  # type: ignore
+                    request.method not in self._BYPASSED_ENDPOINTS[endpoint]  # type: ignore
+                    and self._BYPASSED_ENDPOINTS[endpoint][0] != "*"  # type: ignore
                     # autopep8: on
             ):
 
@@ -61,10 +59,10 @@ class AuthMiddleware:
                         )
 
                 except Exception as e:
-                    return cls._generate_bad_auth_response(exception=e)
+                    return self._generate_bad_auth_response(exception=e)
 
                 if res.status_code != 200:
-                    return cls._generate_bad_auth_response(res.status_code)
+                    return self._generate_bad_auth_response(res.status_code)
 
             response = await call_next(request)
             return response

--- a/packages/py-api/py_api/middleware/exception_handler.py
+++ b/packages/py-api/py_api/middleware/exception_handler.py
@@ -6,8 +6,7 @@ from fastapi.responses import JSONResponse
 
 
 class ExceptionHandler:
-    @staticmethod
-    def bind(app: FastAPI) -> None:
+    def __init__(self, app: FastAPI) -> None:
         @app.exception_handler(Exception)
         async def general_exception_handler(request: Request, exc: Exception) -> JSONResponse:
             content = {

--- a/packages/py-api/py_api/middleware/middleware.py
+++ b/packages/py-api/py_api/middleware/middleware.py
@@ -1,0 +1,19 @@
+
+from typing import Any, List
+
+from fastapi import FastAPI
+from py_api.middleware.analytics import AnalyticsMiddleware
+from py_api.middleware.auth import AuthMiddleware
+from py_api.middleware.exception_handler import ExceptionHandler
+
+
+class Middleware:
+    _middlewares: List[Any] = [
+        AuthMiddleware,
+        AnalyticsMiddleware, ExceptionHandler,
+    ]
+
+    @classmethod
+    def bind(cls, app: FastAPI) -> None:
+        for middleware in cls._middlewares:
+            middleware(app)


### PR DESCRIPTION
Created a middleware for running a background task for updating a document in the database representing the total count of requests made to the server.

The document looks as follows:
<img width="383" alt="image" src="https://github.com/AUBGTheHUB/monolith/assets/104720011/b6dfa9e4-c4d8-48bd-aa02-1364caf7dea5">

How to verify:

- [x] Set IS_PROD environment variable to true
- [x] Make a request
- [x] Check document in analytics collection - total_requests should be updated +1 and in locations you should be able to find your city with an updated request count as well

resolves #498