### PR TITLE
#503 Set up proper CORS origins

### DIFF
--- a/packages/api/app/app.go
+++ b/packages/api/app/app.go
@@ -8,7 +8,6 @@ import (
 	"crypto/tls"
 
 	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/middleware/cors"
 	//fmt, encoding/json, strconv
 )
 
@@ -16,7 +15,7 @@ func StartApp() {
 
 	app := fiber.New()
 	configs.ConnectDB()
-	app.Use(cors.New(cors.ConfigDefault))
+	app.Use(configs.GenerateCORSConfig())
 	routes.MembersRoute(app)
 	routes.AdminRoute(app)
 	routes.JobsRoute(app)

--- a/packages/api/configs/cors.go
+++ b/packages/api/configs/cors.go
@@ -1,0 +1,41 @@
+package configs
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/cors"
+)
+
+func GenerateCORSConfig() func(*fiber.Ctx) error {
+	config := cors.ConfigDefault
+
+	config.AllowOrigins = GenerateOrigins()
+	return cors.New(config)
+}
+
+func GenerateOrigins() string {
+	ALLOWED_LOCALHOST_PROTOCOLS := []string{"http", "https"}
+	ALLOWED_LOCALHOST_DOMAINS := []string{"localhost", "127.0.0.1"}
+	ALLOWED_LOCALHOST_PORTS := []string{"3000", "3001", "6969"}
+	ALLOWED_PUBLIC_DOMAINS := []string{
+		"https://dev.thehub-aubg.com",
+		"https://thehub-aubg.com",
+	}
+
+	var origins []string
+
+	for _, protocol := range ALLOWED_LOCALHOST_PROTOCOLS {
+		for _, domain := range ALLOWED_LOCALHOST_DOMAINS {
+			for _, port := range ALLOWED_LOCALHOST_PORTS {
+				origin := fmt.Sprintf("%s://%s:%s", protocol, domain, port)
+				origins = append(origins, origin)
+			}
+		}
+	}
+
+	origins = append(origins, ALLOWED_PUBLIC_DOMAINS...)
+
+	return strings.Join(origins, ",")
+}

--- a/packages/py-api/py_api/main.py
+++ b/packages/py-api/py_api/main.py
@@ -1,12 +1,15 @@
 
+from typing import Final
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from py_api.middleware import Middleware
 from py_api.routes import Routes
+from py_api.utilities.cors import construct_origins
 from py_api.utilities.logging import get_log_config
 from uvicorn import run
 
-origins = ['*']
+ORIGINS: Final = construct_origins()
 
 main_app = FastAPI()
 app = FastAPI()
@@ -16,7 +19,7 @@ Middleware.bind(app)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=origins,
+    allow_origins=ORIGINS,
     # allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/packages/py-api/py_api/middleware/auth.py
+++ b/packages/py-api/py_api/middleware/auth.py
@@ -19,7 +19,7 @@ from requests import post
 class AuthMiddleware:
     """Utility class for easily initializing all authentication middleware"""
     _BYPASSED_ENDPOINTS: Final = {
-        "/health": ["POST"], "/routes": ["GET"], "/fswitches": ["GET"],
+        "/health": ["GET"], "/routes": ["GET"], "/fswitches": ["GET"],
     }
 
     def __init__(self, app: FastAPI) -> None:

--- a/packages/py-api/py_api/middleware/auth.py
+++ b/packages/py-api/py_api/middleware/auth.py
@@ -19,7 +19,7 @@ from requests import post
 class AuthMiddleware:
     """Utility class for easily initializing all authentication middleware"""
     _BYPASSED_ENDPOINTS: Final = {
-        "/health": ["GET"], "/routes": ["GET"], "/fswitches": ["GET"],
+        "/health": ["POST"], "/routes": ["GET"], "/fswitches": ["GET"],
     }
 
     def __init__(self, app: FastAPI) -> None:

--- a/packages/py-api/py_api/utilities/cors.py
+++ b/packages/py-api/py_api/utilities/cors.py
@@ -1,9 +1,6 @@
 
 
-from logging import getLogger
 from typing import Final, List
-
-logger = getLogger("CORS")
 
 
 def construct_origins() -> List[str]:

--- a/packages/py-api/py_api/utilities/cors.py
+++ b/packages/py-api/py_api/utilities/cors.py
@@ -1,0 +1,23 @@
+
+
+from logging import getLogger
+from typing import Final, List
+
+logger = getLogger("CORS")
+
+
+def construct_origins() -> List[str]:
+    ALLOWED_LOCALHOST_PORTS: Final = [3000, 3001]
+    ALLOWED_LOCALHOST_DOMAINS: Final = ["localhost", "127.0.0.1"]
+    ALLOWED_LOCALHOST_PROTOCOLS: Final = ["http", "https"]
+    origins = [f"{protocol}://{domain}:{port}" for protocol in ALLOWED_LOCALHOST_PROTOCOLS for domain in ALLOWED_LOCALHOST_DOMAINS for port in ALLOWED_LOCALHOST_PORTS]
+
+    # there's no need for ports here since the api is behind a proxy
+    ALLOWED_PUBLIC_DOMAINS = [
+        "https://dev.thehub-aubg.com",
+        "https://thehub-aubg.com",
+    ]
+
+    origins.extend(ALLOWED_PUBLIC_DOMAINS)
+
+    return origins


### PR DESCRIPTION
## Set up proper CORS origins

Allow all localhost aliases with ports 3000, 3001, 6969, https://thehub-aubg.com and https://dev.thehub-aubg.com as origins.

resolves #503 

## How to verify:
- [x] Try to load the frontend and see if any request fails
- [x] Ensure CORS is working by accessing the frontend from a disallowed domain - `fswitches` and `members` requests should fail
<img width="455" alt="image" src="https://github.com/AUBGTheHUB/monolith/assets/104720011/198d39ec-45ae-4b81-b5dc-ad5e4b1d9a36">

