### PR TITLE
Nginx reverse proxy for local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,6 @@ run-py-api:
 run-nginx:
 	cd nginx && docker-compose up --build
 
-.PHONY: run-svelte
-run-svelte:
-	## "dev": "vite dev --port 3001 --host",
-	cd packages/svelte && npm install && npm run dev -- --open
+.PHONY: run-rust-api
+run-rust-api:
+	cd packages/services/url_shortener && make watch

--- a/Makefile
+++ b/Makefile
@@ -90,3 +90,11 @@ install-python:
 .PHONY: run-py-api
 run-py-api:
 	cd packages/py-api && poetry run start
+
+.PHONY: build-nginx
+build-nginx:
+	cd nginx && docker build -t local-nginx .
+
+.PHONY: run-nginx
+run-nginx:
+	docker run -p 80:80 local-nginx

--- a/Makefile
+++ b/Makefile
@@ -91,10 +91,11 @@ install-python:
 run-py-api:
 	cd packages/py-api && poetry run start
 
-.PHONY: build-nginx
-build-nginx:
-	cd nginx && docker build -t local-nginx .
-
 .PHONY: run-nginx
 run-nginx:
-	docker run -p 80:80 local-nginx
+	cd nginx && docker-compose up --build
+
+.PHONY: run-svelte
+run-svelte:
+	## "dev": "vite dev --port 3001 --host",
+	cd packages/svelte && npm install && npm run dev -- --open

--- a/cli.sh
+++ b/cli.sh
@@ -57,8 +57,9 @@ if [ $ACTIONS == $START ]; then
     PROD_CLIENT="Admin Panel (thehub-aubg.com)"
     LOCAL_API="Golang backend"
     LOCAL_PY_API="Python backend"
+    LOCAL_RUST_API="Rust backend"
     NGINX="Reverse Proxy"
-    ACTIONS=$(gum choose --limit 1 "$WEB_CLIENT" "$DEV_CLIENT" "$PROD_CLIENT" "$LOCAL_API" "$LOCAL_PY_API" "$NGINX")
+    ACTIONS=$(gum choose --limit 1 "$WEB_CLIENT" "$DEV_CLIENT" "$PROD_CLIENT" "$LOCAL_API" "$LOCAL_PY_API" "$LOCAL_RUST_API" "$NGINX")
 
     clear
 
@@ -72,6 +73,8 @@ if [ $ACTIONS == $START ]; then
         make reload-api
     elif [ "$ACTIONS" == "$LOCAL_PY_API" ]; then
         make run-py-api
+    elif [ "$ACTIONS" == "$LOCAL_RUST_API" ]; then
+        make run-rust-api
     elif [ "$ACTIONS" == "$NGINX" ]; then
         make run-nginx
     fi

--- a/cli.sh
+++ b/cli.sh
@@ -55,11 +55,10 @@ if [ $ACTIONS == $START ]; then
     WEB_CLIENT="Admin Panel"
     DEV_CLIENT="Admin Panel (dev.thehub-aubg.com)"
     PROD_CLIENT="Admin Panel (thehub-aubg.com)"
-    SVELTE_DEV="Svelte frontend"
     LOCAL_API="Golang backend"
     LOCAL_PY_API="Python backend"
-    NGINX="Run Reverse Proxy"
-    ACTIONS=$(gum choose --limit 1 "$WEB_CLIENT" "$DEV_CLIENT" "$PROD_CLIENT" "$SVELTE_DEV" "$LOCAL_API" "$LOCAL_PY_API" "$NGINX")
+    NGINX="Reverse Proxy"
+    ACTIONS=$(gum choose --limit 1 "$WEB_CLIENT" "$DEV_CLIENT" "$PROD_CLIENT" "$LOCAL_API" "$LOCAL_PY_API" "$NGINX")
 
     clear
 
@@ -73,8 +72,6 @@ if [ $ACTIONS == $START ]; then
         make reload-api
     elif [ "$ACTIONS" == "$LOCAL_PY_API" ]; then
         make run-py-api
-    elif [ "$ACTIONS" == "$SVELTE_DEV" ]; then
-        make run-svelte
     elif [ "$ACTIONS" == "$NGINX" ]; then
         make run-nginx
     fi

--- a/cli.sh
+++ b/cli.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-current_directory=${PWD##*/} 
+current_directory=${PWD##*/}
 
 set_vm_ip () {
     if [[ $HUB_VM ]]; then
@@ -29,7 +29,7 @@ set_vm_ip () {
 
 if [[ $current_directory != "spa-website-2022" && $current_directory != "monolith" ]]
 then
-    echo "Run this script from the root of the SPA project"
+    echo "Run this script from the root of the monolith"
     exit 1
 fi
 
@@ -39,7 +39,7 @@ then
     make install-gum
 fi
 
-gum style --border normal --margin "1" --padding "1 2" --border-foreground 212 "Hello, there! Welcome to The Hub's $(gum style --foreground 212 'SPA project')."
+gum style --border normal --margin "1" --padding "1 2" --border-foreground 212 "Hello, there! Welcome to The Hub's $(gum style --foreground 212 'monolith')."
 
 echo -e "What would you like to do?"
 
@@ -52,16 +52,18 @@ if [ $ACTIONS == $START ]; then
     clear
     echo -e "What instance do you want to spin up?"
 
-    WEB_CLIENT="Client (local)"
-    DEV_CLIENT="Client (dev)"
-    PROD_CLIENT="Client (prod)"
-    LOCAL_API="Run Go Api"
-    LOCAL_PY_API="Run Python Api"
-    ACTIONS=$(gum choose --limit 1 "$WEB_CLIENT" "$DEV_CLIENT" "$PROD_CLIENT" "$LOCAL_API" "$LOCAL_PY_API")
+    WEB_CLIENT="Admin Panel"
+    DEV_CLIENT="Admin Panel (dev.thehub-aubg.com)"
+    PROD_CLIENT="Admin Panel (thehub-aubg.com)"
+    SVELTE_DEV="Svelte frontend"
+    LOCAL_API="Golang backend"
+    LOCAL_PY_API="Python backend"
+    NGINX="Run Reverse Proxy"
+    ACTIONS=$(gum choose --limit 1 "$WEB_CLIENT" "$DEV_CLIENT" "$PROD_CLIENT" "$SVELTE_DEV" "$LOCAL_API" "$LOCAL_PY_API" "$NGINX")
 
     clear
 
-    if [ "$ACTIONS" == "$WEB_CLIENT" ]; then 
+    if [ "$ACTIONS" == "$WEB_CLIENT" ]; then
         make run-web
     elif [ "$ACTIONS" == "$DEV_CLIENT" ]; then
         make run-dev
@@ -71,6 +73,10 @@ if [ $ACTIONS == $START ]; then
         make reload-api
     elif [ "$ACTIONS" == "$LOCAL_PY_API" ]; then
         make run-py-api
+    elif [ "$ACTIONS" == "$SVELTE_DEV" ]; then
+        make run-svelte
+    elif [ "$ACTIONS" == "$NGINX" ]; then
+        make run-nginx
     fi
 
 elif [ "$ACTIONS" == "$DEPLOY" ]; then
@@ -83,7 +89,7 @@ elif [ "$ACTIONS" == "$DEPLOY" ]; then
     if [ "$ACTIONS" == "$LOGIN_IN_VM" ]; then
         set_vm_ip
         ssh $VM_IP
-    
+
     elif [ "$ACTIONS" == "$SET_VM_ENV" ]; then
         set_vm_ip
         ssh -t $VM_IP "curl https://raw.githubusercontent.com/AUBGTheHUB/spa-website-2022/master/set_vm_env.sh | bash"

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,13 @@
+# Use the official Nginx base image
+FROM nginx:latest
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+EXPOSE 443
+EXPOSE 3000
+EXPOSE 3001
+EXPOSE 6969
+EXPOSE 8000
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -4,10 +4,5 @@ FROM nginx:latest
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
-EXPOSE 443
-EXPOSE 3000
-EXPOSE 3001
-EXPOSE 6969
-EXPOSE 8000
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/docker-compose.yml
+++ b/nginx/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+
+services:
+
+  nginx:
+    build:
+      context: .
+    container_name: local_nginx
+    expose:
+      - 80
+    ports:
+      - 80:80

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -3,16 +3,6 @@ server {
     listen 80 default_server;
 
     location / {
-        proxy_pass http://192.168.198.100:3001;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection 'upgrade';
-        proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_cache_bypass $http_upgrade;
-    }
-
-    location /admin {
         proxy_pass http://192.168.198.100:3000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,54 @@
+server {
+    server_name localhost;
+    listen 80 default_server;
+
+    location / {
+        proxy_pass http://192.168.198.100:3001;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    location /admin {
+        proxy_pass http://192.168.198.100:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    location /v2 {
+        proxy_pass http://192.168.198.100:6969;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    location /api {
+        proxy_pass http://192.168.198.100:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    location /s {
+        proxy_pass http://192.168.198.100:8001;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_cache_bypass $http_upgrade;
+    }
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -42,7 +42,7 @@ server {
         proxy_cache_bypass $http_upgrade;
     }
 
-    location /s {
+    location /s/ {
         proxy_pass http://192.168.198.100:8001;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,3 +1,6 @@
+# in order to be able to properly set the reverse proxy to point to the admin panel
+# you need ot add the following in the package.json file "homepage": "/admin/"
+
 server {
     server_name localhost;
     listen 80 default_server;

--- a/packages/api/configs/cors.go
+++ b/packages/api/configs/cors.go
@@ -22,6 +22,7 @@ func GenerateOrigins() string {
 	ALLOWED_PUBLIC_DOMAINS := []string{
 		"https://dev.thehub-aubg.com",
 		"https://thehub-aubg.com",
+		"http://local.thehub-aubg.com",
 	}
 
 	var origins []string

--- a/packages/py-api/py_api/utilities/cors.py
+++ b/packages/py-api/py_api/utilities/cors.py
@@ -13,6 +13,7 @@ def construct_origins() -> List[str]:
     ALLOWED_PUBLIC_DOMAINS = [
         "https://dev.thehub-aubg.com",
         "https://thehub-aubg.com",
+        "http://local.thehub-aubg.com",
     ]
 
     origins.extend(ALLOWED_PUBLIC_DOMAINS)

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -2,7 +2,6 @@
     "name": "web",
     "version": "0.1.0",
     "private": true,
-    "homepage": "/admin/",
     "dependencies": {
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -2,6 +2,7 @@
     "name": "web",
     "version": "0.1.0",
     "private": true,
+    "homepage": "/admin/",
     "dependencies": {
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",

--- a/packages/web/public/index.html
+++ b/packages/web/public/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
     <head>
         <meta charset="utf-8" />
@@ -8,8 +8,7 @@
         <meta
             name="description"
             content="The IT and innovations club at the American University in
-                    Bulgaria."
-        />
+                    Bulgaria." />
         <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
         <!--
       manifest.json provides metadata used when your web app is installed on a


### PR DESCRIPTION
## UPDATE:
Reverse proxy POC is accepted but moving to Svelte is still being discussed. Updated the PR to include only the reverse proxy changes which will help developers set up proper requests since it's imitating how requests are being proxied on deployed environments.

## OLD:
In order to be able to run Svelte as the main frontend and still have access to the react admin panel, we have to place all services behind a reverse proxy.

![image](https://github.com/AUBGTheHUB/monolith/assets/104720011/349abdaf-3a7e-4b7a-83e0-6d447e7b3ea7)

How to test the POC:
- [x] Download docker
- [ ] ~~`make build-nginx` and `make run-nginx` to build and run the nginx container~~
- [ ] ~~`make run-svelte` to install all dependencies and run svelte~~. 
- [x] Use `make gum` to start all services you need (you need to start reverse proxy)
![image](https://github.com/AUBGTheHUB/monolith/assets/104720011/1a78097f-d6ed-48b0-9d9b-10ef0de5c65a)

- [x] Access svelte on http://localhost and react on http://localhost/admin (optionally you can add http://local.thehub-aubg.com as an alias hostname in `/etc/hosts`)
![image](https://github.com/AUBGTheHUB/monolith/assets/104720011/5a13d103-72d9-4ec0-9a64-f78110499340)

If we decide to proceed with using Svelte, we would need to double down on cleaning up all redundant code from the admin panel. Additionally, we will need to drop all current svelte files and generate a new empty project.