### PR TITLE
Fix mobile width because text is cut at the end

### DIFF
--- a/packages/services/questionnaire/src/routes/questionnaires/[department]/+page.svelte
+++ b/packages/services/questionnaire/src/routes/questionnaires/[department]/+page.svelte
@@ -95,7 +95,7 @@
         gap: 0.3rem !important;
     }
 
-    @media (max-width: 640px) {
+    @media (max-width: 800px) {
         .custom-width {
             width: 95%;
         }

--- a/packages/services/questionnaire/src/routes/questionnaires/[department]/+page.svelte
+++ b/packages/services/questionnaire/src/routes/questionnaires/[department]/+page.svelte
@@ -97,7 +97,7 @@
 
     @media (max-width: 640px) {
         .custom-width {
-            width: 90%;
+            width: 95%;
         }
     }
 


### PR DESCRIPTION
## Fixed cut text on mobile device
Edited width property because text was not being displayed properly