### PR TITLE
#550 Remove new line from branch name

### DIFF
--- a/manage_app.py
+++ b/manage_app.py
@@ -415,8 +415,9 @@ def cron_git_check_for_updates():
         branch_name = subprocess.run(
             ['git', 'rev-parse', '--abbrev-ref', 'HEAD'], capture_output=True, text=True,
         )
+        branch_name = branch_name.stdout.replace("\n", "")
         subprocess.run(
-            ['git', 'reset', '--hard', f'origin/{branch_name.stdout}'],
+            ['git', 'reset', '--hard', f'origin/{branch_name}'],
         )
         subprocess.run(
             ['git', 'pull'], capture_output=True, text=True,


### PR DESCRIPTION
Removed the "\n" character from the name of the branch because it was causing 

![378249898_6953122394699464_1585113149718848644_n](https://github.com/AUBGTheHUB/monolith/assets/38375079/8974f9a1-2fb2-4b46-ae07-9a00391ebeb0)

We will have to see if this really fixes the problem
Fix #550 

