### PR TITLE
Added submission times to the csv export from MongoDB

### DIFF
--- a/packages/py-api/py_api/controllers/questionnaires_controller.py
+++ b/packages/py-api/py_api/controllers/questionnaires_controller.py
@@ -1,8 +1,8 @@
-from fastapi.responses import JSONResponse, StreamingResponse
-
-from py_api.database import q_col, a_col
-import pandas as pd
 import io
+
+import pandas as pd
+from fastapi.responses import JSONResponse, StreamingResponse
+from py_api.database import a_col, q_col
 
 
 class QuestionnairesController:
@@ -15,12 +15,21 @@ class QuestionnairesController:
             return JSONResponse(content={"message": "Questionnaire doesn't exist"}, status_code=404)
 
         questions = [q['title'] for q in questions['questions']]
+        questions.append("Submition time")
 
         answers = a_col.find({'department': dep})
         answers = [list(a['answers'].values()) for a in answers]
 
-        docs = pd.DataFrame(answers, columns=questions).replace(
-            r'^s*$', float('NaN'), regex=True)
+        # I need to query the answers again because once I itereate over them then down below the answers list is empty
+        submission_timestamps = [
+            str(a["_id"].generation_time)
+            for a in a_col.find({'department': dep})
+        ]
+
+        data = [a + [s] for a, s in zip(answers, submission_timestamps)]
+        docs = pd.DataFrame(data, columns=questions).replace(
+            r'^s*$', float('NaN'), regex=True,
+        )
 
         docs.dropna(axis=0, how='all', inplace=True)
 
@@ -28,7 +37,8 @@ class QuestionnairesController:
         docs.to_csv(stream, index=False)
 
         response = StreamingResponse(
-            iter([stream.getvalue()]), media_type='text/csv')
+            iter([stream.getvalue()]), media_type='text/csv',
+        )
         response.headers["Content-Disposition"] = f"attachment; filename={dep}.csv"
 
         return response

--- a/packages/py-api/py_api/controllers/questionnaires_controller.py
+++ b/packages/py-api/py_api/controllers/questionnaires_controller.py
@@ -15,7 +15,7 @@ class QuestionnairesController:
             return JSONResponse(content={"message": "Questionnaire doesn't exist"}, status_code=404)
 
         questions = [q['title'] for q in questions['questions']]
-        questions.append("Submition time")
+        questions.append("Submission time")
 
         answers = a_col.find({'department': dep})
         answers = [list(a['answers'].values()) for a in answers]


### PR DESCRIPTION
## Added webhooks for triggering something:
Added a new column called "Submission time" to the CSV export so that we could compare the timestamps of creation more easily

## How to verify:

- [ ] go to `v2/questionnaires/csv/emailtest` in Postman and save the response as .csv


