### PR TITLE
Added check when updating participant

### DIFF
--- a/packages/py-api/py_api/controllers/hackathon_participants_controller.py
+++ b/packages/py-api/py_api/controllers/hackathon_participants_controller.py
@@ -49,12 +49,19 @@ class ParticipantsController:
         fields_to_be_updated = filter_none_values(participant_form)
 
         # Queries the given participant and updates it
-        to_be_updated_participant = participants_col.find_one_and_update(
-            {"_id": ObjectId(object_id)}, {
-                "$set": fields_to_be_updated,
-            },
-            return_document=True,
-        )
+        try:
+            to_be_updated_participant = participants_col.find_one_and_update(
+                {"_id": ObjectId(object_id)}, {
+                    "$set": fields_to_be_updated,
+                },
+                return_document=True,
+            )
+
+        except (InvalidId, TypeError) as e:
+            return JSONResponse(content={"message": "Invalid object_id format!"}, status_code=400)
+
+        if not to_be_updated_participant:
+            return JSONResponse(content={"message": "The targeted participant was not found!"}, status_code=404)
 
         return JSONResponse(content={"participant": json.loads(dumps(to_be_updated_participant))}, status_code=200)
 


### PR DESCRIPTION
#589 Add a check for put request if the participant does not exist

I enclosed the find_and_update method call within a try-catch block to check for an invalid objectID type. Moreover, if the objectID is correct I check if that participant exists. 

## How to verify:

- [ ] Start the Python backend

- [ ] Open Postman

- [ ] Create a PUT request template

- [ ] Send the request at /v2/hackathon/participants/{ObjectId}

- [ ] Test with an invalid ObjectId type and then with an ObjectId that does not exist 

- [ ] Look at the error messages

