### PR TITLE
669 refactors random participant creation block

### DIFF
--- a/packages/py-api/py_api/controllers/hackathon/participants_controller.py
+++ b/packages/py-api/py_api/controllers/hackathon/participants_controller.py
@@ -11,6 +11,7 @@ from py_api.functionality.hackathon.jwt_base import JWTFunctionality
 from py_api.functionality.hackathon.participants_base import ParticipantsFunctionality
 from py_api.functionality.hackathon.teams_base import TeamFunctionality
 from py_api.models import NewParticipant, UpdateParticipant
+from py_api.models.hackathon_teams_models import HackathonTeam
 from py_api.utilities.parsers import filter_none_values
 from starlette.responses import JSONResponse
 
@@ -240,64 +241,70 @@ class ParticipantsController:
 
             # Find the teams which can accept a new participant
             for team in random_teams:
-
                 if (len(team.team_members) < 6):
-                    avaliable_team = team
-                    try:
-                        # Creates new participant
-                        new_participant = ParticipantsFunctionality.create_participant(
-                            participant,
-                        )
+                    return cls.add_participant_to_existing_random_team(team, participant)
 
-                        new_participant_object_id = str(
-                            new_participant.inserted_id,
-                        )
-                        # Adds the participant to the team
-                        avaliable_team = TeamFunctionality.add_participant_to_team_object(
-                            avaliable_team.team_name, new_participant_object_id,
-                        )
-                        cls.update_participant(
-                            new_participant_object_id, UpdateParticipant(
-                                team_name=avaliable_team.team_name,
-                            ),
-                        )
-                        TeamFunctionality.update_team_query_using_dump(
-                            avaliable_team.model_dump(),
-                        )
-                        return JSONResponse(content=avaliable_team.model_dump(), status_code=200)
-
-                    except (Exception) as e:
-                        return JSONResponse(content={"message": str(e)}, status_code=500)
-
-            # If all the random teams are full, it checks if there is space for creating a new one
+            # If all the random teams are full, check if there is space for creating a new one
             if (TeamFunctionality.get_count_of_teams() < 15):
-                try:
-                    # Creates new participant
-                    new_participant = ParticipantsFunctionality.create_participant(
-                        participant,
-                    )
-
-                    new_participant_object_id = str(
-                        new_participant.inserted_id,
-                    )
-                    # Create New Team and assign the new participant to it
-                    newTeam = TeamFunctionality.create_team_object_with_admin(
-                        user_id=new_participant_object_id, team_name=TeamFunctionality.generate_random_team_name(), generate_random_team=True,
-                    )
-
-                    if newTeam:
-                        cls.update_participant(
-                            new_participant_object_id, UpdateParticipant(
-                                team_name=newTeam.team_name,
-                            ),
-                        )
-                        TeamFunctionality.insert_team(newTeam)
-                        return JSONResponse(content=newTeam.model_dump(), status_code=200)
-                    else:
-                        return JSONResponse(content={"message": "Couldn't create team, because a team of the same name already exists!"}, status_code=422)
-
-                except (Exception) as e:
-                    return JSONResponse(content={"message": str(e)}, status_code=500)
+                return cls.add_participant_to_new_random_team(participant)
 
             else:
                 return JSONResponse(content={"message": "The maximum number of teams is reached."}, status_code=409)
+
+    @classmethod
+    def add_participant_to_existing_random_team(cls, available_team: HackathonTeam, participant: NewParticipant) -> JSONResponse:
+        try:
+            # Creates new participant
+            new_participant = ParticipantsFunctionality.create_participant(
+                participant,
+            )
+
+            new_participant_object_id = str(
+                new_participant.inserted_id,
+            )
+            # Adds the participant to the team
+            available_team = TeamFunctionality.add_participant_to_team_object(
+                available_team.team_name, new_participant_object_id,
+            )
+            cls.update_participant(
+                new_participant_object_id, UpdateParticipant(
+                    team_name=available_team.team_name,
+                ),
+            )
+            TeamFunctionality.update_team_query_using_dump(
+                available_team.model_dump(),
+            )
+            return JSONResponse(content=available_team.model_dump(), status_code=200)
+
+        except (Exception) as e:
+            return JSONResponse(content={"message": str(e)}, status_code=500)
+
+    @classmethod
+    def add_participant_to_new_random_team(cls, participant: NewParticipant) -> JSONResponse:
+        try:
+            # Creates new participant
+            new_participant = ParticipantsFunctionality.create_participant(
+                participant,
+            )
+
+            new_participant_object_id = str(
+                new_participant.inserted_id,
+            )
+            # Create New Team and assign the new participant to it
+            newTeam = TeamFunctionality.create_team_object_with_admin(
+                user_id=new_participant_object_id, team_name=TeamFunctionality.generate_random_team_name(), generate_random_team=True,
+            )
+
+            if newTeam:
+                cls.update_participant(
+                    new_participant_object_id, UpdateParticipant(
+                        team_name=newTeam.team_name,
+                    ),
+                )
+                TeamFunctionality.insert_team(newTeam)
+                return JSONResponse(content=newTeam.model_dump(), status_code=200)
+            else:
+                return JSONResponse(content={"message": "Couldn't create team, because a team of the same name already exists!"}, status_code=422)
+
+        except (Exception) as e:
+            return JSONResponse(content={"message": str(e)}, status_code=500)

--- a/packages/py-api/py_api/controllers/hackathon/participants_controller.py
+++ b/packages/py-api/py_api/controllers/hackathon/participants_controller.py
@@ -266,7 +266,7 @@ class ParticipantsController:
             available_team = TeamFunctionality.add_participant_to_team_object(
                 available_team.team_name, new_participant_object_id,
             )
-            cls.update_participant(
+            ParticipantsFunctionality.update_participant(
                 new_participant_object_id, UpdateParticipant(
                     team_name=available_team.team_name,
                 ),
@@ -296,15 +296,16 @@ class ParticipantsController:
             )
 
             if newTeam:
-                cls.update_participant(
+                ParticipantsFunctionality.update_participant(
                     new_participant_object_id, UpdateParticipant(
                         team_name=newTeam.team_name,
                     ),
                 )
+
                 TeamFunctionality.insert_team(newTeam)
                 return JSONResponse(content=newTeam.model_dump(), status_code=200)
-            else:
-                return JSONResponse(content={"message": "Couldn't create team, because a team of the same name already exists!"}, status_code=422)
+
+            return JSONResponse(content={"message": "Couldn't create team, because a team of the same name already exists!"}, status_code=422)
 
         except (Exception) as e:
             return JSONResponse(content={"message": str(e)}, status_code=500)

--- a/packages/py-api/py_api/controllers/hackathon/participants_controller.py
+++ b/packages/py-api/py_api/controllers/hackathon/participants_controller.py
@@ -269,24 +269,29 @@ class ParticipantsController:
                         return JSONResponse(content={"message": e.args}, status_code=422)
 
             if (TeamFunctionality.get_count_of_teams() < 15):
-                # Creates new participant
-                new_participant = ParticipantsFunctionality.create_participant(
-                    participant,
-                )
-                new_participant_object_id = str(new_participant.inserted_id)
-                # Create New Team and assign the new participant to it
-                newTeam = TeamFunctionality.create_team_object_with_admin(
-                    user_id=new_participant_object_id, team_name=TeamFunctionality.generate_random_team_name(), generate_random_team=True,
-                )
-
-                if newTeam:
-                    cls.update_participant(
-                        new_participant_object_id, UpdateParticipant(
-                            **{"team_name": newTeam.team_name}
-                        ),
+                try:
+                    # Creates new participant
+                    new_participant = ParticipantsFunctionality.create_participant(
+                        participant,
                     )
-                    TeamFunctionality.insert_team(newTeam)
-                    return JSONResponse(content=newTeam.model_dump(), status_code=200)
+                    new_participant_object_id = str(
+                        new_participant.inserted_id,
+                    )
+                    # Create New Team and assign the new participant to it
+                    newTeam = TeamFunctionality.create_team_object_with_admin(
+                        user_id=new_participant_object_id, team_name=TeamFunctionality.generate_random_team_name(), generate_random_team=True,
+                    )
+
+                    if newTeam:
+                        cls.update_participant(
+                            new_participant_object_id, UpdateParticipant(
+                                **{"team_name": newTeam.team_name}
+                            ),
+                        )
+                        TeamFunctionality.insert_team(newTeam)
+                        return JSONResponse(content=newTeam.model_dump(), status_code=200)
+                except (Exception) as e:
+                    return JSONResponse(content={"message": e.args}, status_code=422)
                 else:
                     return JSONResponse(content={"message": "Couldn't create team, because a team of the same name already exists!"}, status_code=422)
 

--- a/packages/py-api/py_api/controllers/hackathon/participants_controller.py
+++ b/packages/py-api/py_api/controllers/hackathon/participants_controller.py
@@ -248,6 +248,7 @@ class ParticipantsController:
                         new_participant = ParticipantsFunctionality.create_participant(
                             participant,
                         )
+
                         new_participant_object_id = str(
                             new_participant.inserted_id,
                         )
@@ -266,14 +267,16 @@ class ParticipantsController:
                         return JSONResponse(content=avaliable_team.model_dump(), status_code=200)
 
                     except (Exception) as e:
-                        return JSONResponse(content={"message": e.args}, status_code=422)
+                        return JSONResponse(content={"message": str(e)}, status_code=500)
 
+            # If all the random teams are full, it checks if there is space for creating a new one
             if (TeamFunctionality.get_count_of_teams() < 15):
                 try:
                     # Creates new participant
                     new_participant = ParticipantsFunctionality.create_participant(
                         participant,
                     )
+
                     new_participant_object_id = str(
                         new_participant.inserted_id,
                     )
@@ -290,10 +293,11 @@ class ParticipantsController:
                         )
                         TeamFunctionality.insert_team(newTeam)
                         return JSONResponse(content=newTeam.model_dump(), status_code=200)
+                    else:
+                        return JSONResponse(content={"message": "Couldn't create team, because a team of the same name already exists!"}, status_code=422)
+
                 except (Exception) as e:
-                    return JSONResponse(content={"message": e.args}, status_code=422)
-                else:
-                    return JSONResponse(content={"message": "Couldn't create team, because a team of the same name already exists!"}, status_code=422)
+                    return JSONResponse(content={"message": str(3)}, status_code=500)
 
             else:
                 return JSONResponse(content={"message": "The maximum number of teams is reached."}, status_code=409)

--- a/packages/py-api/py_api/controllers/hackathon/participants_controller.py
+++ b/packages/py-api/py_api/controllers/hackathon/participants_controller.py
@@ -258,7 +258,7 @@ class ParticipantsController:
                         )
                         cls.update_participant(
                             new_participant_object_id, UpdateParticipant(
-                                **{"team_name": avaliable_team.team_name}
+                                team_name=avaliable_team.team_name,
                             ),
                         )
                         TeamFunctionality.update_team_query_using_dump(
@@ -288,7 +288,7 @@ class ParticipantsController:
                     if newTeam:
                         cls.update_participant(
                             new_participant_object_id, UpdateParticipant(
-                                **{"team_name": newTeam.team_name}
+                                team_name=newTeam.team_name,
                             ),
                         )
                         TeamFunctionality.insert_team(newTeam)
@@ -297,7 +297,7 @@ class ParticipantsController:
                         return JSONResponse(content={"message": "Couldn't create team, because a team of the same name already exists!"}, status_code=422)
 
                 except (Exception) as e:
-                    return JSONResponse(content={"message": str(3)}, status_code=500)
+                    return JSONResponse(content={"message": str(e)}, status_code=500)
 
             else:
                 return JSONResponse(content={"message": "The maximum number of teams is reached."}, status_code=409)

--- a/packages/py-api/py_api/functionality/hackathon/participants_base.py
+++ b/packages/py-api/py_api/functionality/hackathon/participants_base.py
@@ -25,7 +25,7 @@ class ParticipantsFunctionality:
         if new_participant.acknowledged:
             return new_participant
 
-        raise Exception("Could not add participant")
+        raise Exception("Could not create participant")
 
     @classmethod
     def delete_participant(cls, id: str) -> results.DeleteResult | None:

--- a/packages/py-api/py_api/functionality/hackathon/participants_base.py
+++ b/packages/py-api/py_api/functionality/hackathon/participants_base.py
@@ -20,8 +20,12 @@ class ParticipantsFunctionality:
         return False
 
     @classmethod
-    def create_participant(cls, participant: NewParticipant) -> results.InsertOneResult | None:
-        return cls.pcol.insert_one(participant.model_dump())
+    def create_participant(cls, participant: NewParticipant) -> results.InsertOneResult:
+        new_participant = cls.pcol.insert_one(participant.model_dump())
+        if new_participant.acknowledged:
+            return new_participant
+
+        raise Exception("Could not add participant")
 
     @classmethod
     def delete_participant(cls, id: str) -> results.DeleteResult | None:

--- a/packages/py-api/py_api/functionality/hackathon/teams_base.py
+++ b/packages/py-api/py_api/functionality/hackathon/teams_base.py
@@ -42,7 +42,7 @@ class TeamFunctionality:
     def add_participant_to_team_object(
             cls, team_name: str,
             user_id: str,
-    ) -> HackathonTeam | None:
+    ) -> HackathonTeam:
         """ fetches a HackathonTeam object and updates it without inserting it back in the database """
         team = cls.fetch_team(team_name=team_name)
 
@@ -75,6 +75,12 @@ class TeamFunctionality:
             return None
 
         return HackathonTeam(**team)
+
+    @classmethod
+    def fetch_teams_by_condition(cls, conditions: Dict[str, Any]) -> List[HackathonTeam]:
+        # if conditions are empty it will return all the teams
+        filtered_teams = list(t_col.find(conditions))
+        return [HackathonTeam(**team) for team in filtered_teams]
 
     @classmethod
     def update_team_query_using_dump(

--- a/packages/py-api/py_api/functionality/hackathon/teams_base.py
+++ b/packages/py-api/py_api/functionality/hackathon/teams_base.py
@@ -1,11 +1,10 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from bson import ObjectId
 from py_api.database.initialize import t_col
 from py_api.models import HackathonTeam
 from py_api.models.hackathon_teams_models import TeamType
 from pymongo import results
-from pymongo.results import UpdateResult
 
 
 class TeamFunctionality:


### PR DESCRIPTION
Refactored the block located in the add_participant function which deals with the creation and addition of a new random participant to either an existing random team or a new random team if there are any spaces. What I did is I created two separate functions for the possible scenarios and applied the existing logic in both of them. 
Additionally, I removed some unused imports from the teams_base file.

## How to verify:

- [ ] Start Python backend server

- [ ] Send a POST request to the participants endpoint, with the info of a new random participant

- [ ] Check the returning JSON. 

- [ ] If completed successfully, it will return the new team with the added participant

- [ ] Otherwise, you shall be able to read a meaningful error

