### PR TITLE
662 Implements sending successful registration messages to participants

### DIFF
--- a/packages/py-api/py_api/controllers/hackathon/verification_controller.py
+++ b/packages/py-api/py_api/controllers/hackathon/verification_controller.py
@@ -44,10 +44,9 @@ class VerificationController:
                 team_payload=team.model_dump(),
             )
 
-        if team.team_type == team.team_type.NORMAL:
-
-            # Invite link is sent to the admin
-            try:
+        try:
+            if team.team_type == team.team_type.NORMAL:
+                # Invite link is sent to the admin along with verification message
                 jwt_token = JWTFunctionality.create_jwt_token(
                     team_name=team.team_name, is_invite=True,
                 )
@@ -56,14 +55,23 @@ class VerificationController:
                     send_email_background_task, verified_participant.get(
                         "email",
                     ), "Test",
-                    f"Url: {JWTFunctionality.get_email_link(jwt_token, for_frontend=True, is_invite=True)}",
+                    f"You have successfully registred from HACKAUBG 6.0. To invite your teamates to join your team use the following link. \n Url: {JWTFunctionality.get_email_link(jwt_token, for_frontend=True, is_invite=True)}",
                 )
 
-            except Exception as e:
-                return JSONResponse(
-                    content={"error": str(e)},
-                    status_code=500,
+            else:
+                # Verification email is sent to the random team participant
+                background_tasks.add_task(
+                    send_email_background_task, verified_participant.get(
+                        "email",
+                    ), "HackAUBG registration confirmation",
+                    f"You have successfully been registred to HACKAUBG 6.0! Happy Coding!",
                 )
+
+        except Exception as e:
+            return JSONResponse(
+                content={"error": str(e)},
+                status_code=500,
+            )
 
         return JSONResponse(
             content={"message": "Participant was successfully verified"}, status_code=200,

--- a/packages/py-api/py_api/functionality/hackathon/teams_base.py
+++ b/packages/py-api/py_api/functionality/hackathon/teams_base.py
@@ -141,4 +141,4 @@ class TeamFunctionality:
 
     @classmethod
     def get_count_of_teams(cls) -> int:
-        return int(t_col.count_documents({}))
+        return len(cls.fetch_teams_by_condition({"is_verified": True}))


### PR DESCRIPTION


## Implemented sending a successful registration message to the participants:
I added a background task in the verification controller to send an email to the verified random participant and modified the message sent to the admin of a normal team to also include a successful registration message. Furthermore, for the participants who are registered by link, the logic for sending the email is implemented in the participant's controller in the method named add_participant_to_existing_team(), because they are verified by default and they dont use the verify endpoint. I also changed some confusing logic about how the check for the capacity reach was made in the add_participant method to something that I think is more clear and correct. The previous version wasn't letting you add a participant to an existing team when the number of teams had reached the cap. This was because it had a check in the beginning of the file which returned a json response when the cap was reached with causing issues to the logic of the code. 
Lastly, I changed the method get_count_of_teams to only count the verified teams in the database.

resolves #662  

## How to verify:

- [ ] Start the backend

- [ ] Register as a participant with a team, as a random participant and as a participant with invitation link. 

- [ ] Check the emails that you have received. 

