### PR TITLE
Add participants to team on email verification

### DIFF
--- a/packages/py-api/py_api/controllers/hackathon/participants_controller.py
+++ b/packages/py-api/py_api/controllers/hackathon/participants_controller.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Callable, Dict
+from typing import Dict
 
 from bson.json_util import dumps
 from fastapi import BackgroundTasks
@@ -7,14 +7,13 @@ from fastapi.responses import JSONResponse
 from py_api.database.database_transaction_handlers import (
     handle_database_session_transaction,
 )
-from py_api.database.initialize import client, participants_col
+from py_api.database.initialize import participants_col
 from py_api.functionality.hackathon.jwt_base import JWTFunctionality
 from py_api.functionality.hackathon.mailing_functionality import MailingFunctionality
 from py_api.functionality.hackathon.participants_base import ParticipantsFunctionality
 from py_api.functionality.hackathon.teams_base import TeamFunctionality
 from py_api.models import NewParticipant, UpdateParticipant
 from py_api.models.hackathon_teams_models import HackathonTeam
-from py_api.services.mailer import send_email_background_task
 from pymongo.client_session import ClientSession
 
 
@@ -84,10 +83,11 @@ class ParticipantsController:
             return JSONResponse(content={"error": str(e)}, status_code=500)
 
     @classmethod
+    @handle_database_session_transaction
     def update_participant(
             cls,
             object_id: str,
-            info_to_be_updated: UpdateParticipant,
+            info_to_be_updated: UpdateParticipant, session: ClientSession,
     ) -> JSONResponse:
         try:
 
@@ -101,7 +101,7 @@ class ParticipantsController:
 
             # Queries the given participant and updates it
             updated_participant = ParticipantsFunctionality.update_participant(
-                object_id, info_to_be_updated,
+                object_id, info_to_be_updated, session=session,
             )
 
             return JSONResponse(
@@ -127,26 +127,25 @@ class ParticipantsController:
             # the frontend
             return cls.handle_registration_via_invite_link(jwt_token, participant)
 
-        # Logic for adding a random participant to an existing team
-        if not participant.team_name:
-            # Fetch the teams of type random
-            random_teams = TeamFunctionality.fetch_teams_by_condition(
-                {"team_type": "random"},
-            )
-            # Find the teams which can accept a new participant and add it if there is space
-            for team in random_teams:
-                if len(team.team_members) < 6:
-                    return cls.add_participant_to_existing_team(participant, team)
-
-        # Logic for creating a new team and adding the admin
         if TeamFunctionality.get_count_of_teams() < 16:
             if participant.team_name:
-                # The participant has provided a team name upon registration, so we assign them as admin to the newly
-                # created team
-                return cls.add_participant_to_new_team(participant)
+                if TeamFunctionality.fetch_team(team_name=participant.team_name):
+                    return JSONResponse(content={"message": "Team with this name already exists"}, status_code=409)
+
+                return cls.add_participant_to_db(participant, is_participant_random=False)
             else:
-                # The participant hasn't provided a team name upon registration, so we assign the admin to the newly created random team
-                return cls.add_participant_to_new_team(participant, generate_random_team=True)
+                return cls.add_participant_to_db(participant, is_participant_random=True)
+
+        # # Logic for adding a random participant to an existing team
+        # if not participant.team_name:
+        #     # Fetch the teams of type random
+        #     random_teams = TeamFunctionality.fetch_teams_by_condition(
+        #         {"team_type": "random"},
+        #     )
+        #     # Find the teams which can accept a new participant and add it if there is space
+        #     for team in random_teams:
+        #         if len(team.team_members) < 6:
+        #             return cls.add_participant_to_existing_team(participant, team)
 
         return JSONResponse(content={"message": "Hackathon is at maximum capacity"}, status_code=409)
 
@@ -225,43 +224,31 @@ class ParticipantsController:
 
     @classmethod
     @handle_database_session_transaction
-    def add_participant_to_new_team(
-            cls, participant: NewParticipant, session: ClientSession,
-            generate_random_team: bool = False,
+    def add_participant_to_db(
+            cls, participant: NewParticipant, session: ClientSession, is_participant_random: bool,
     ) -> JSONResponse:
-        participant.is_admin = True
+        """Adds a participant to the database as admin of a team and sends them a verification email."""
+
+        # Every first member of a non-random team is an admin
+        if not is_participant_random:
+            participant.is_admin = True
+
         new_participant = ParticipantsFunctionality.insert_participant(
             participant, session,
         )
 
-        new_participant_object_id = str(new_participant.inserted_id)
-
-        new_team = TeamFunctionality.create_team_object_with_admin(
-            user_id=new_participant_object_id,
-            team_name=TeamFunctionality.generate_random_team_name()
-            if generate_random_team else participant.team_name,
-            generate_random_team=generate_random_team,
-        )
-        if not new_team:
-            session.abort_transaction()
-            return JSONResponse(
-                content={
-                    "message": "Couldn't create team, because a team of the same name already exists!",
-                },
-                status_code=409,
-            )
-
-        TeamFunctionality.insert_team(new_team, session)
-
         jwt_token = JWTFunctionality.create_jwt_token(
-            new_participant_object_id, new_team.team_name,
+            str(new_participant.inserted_id), participant.team_name, is_participant_random=is_participant_random,
         )
 
         background_tasks = BackgroundTasks()
         background_tasks.add_task(
             MailingFunctionality.send_verification_email, email=participant.email, jwt_token=jwt_token,
-            team_name=participant.team_name if not generate_random_team else None,
+            team_name=participant.team_name,
             participant_name=participant.first_name,
         )
 
-        return JSONResponse(content=new_team.model_dump(), status_code=200, background=background_tasks)
+        return JSONResponse(
+            content={"message": "New participant successfully created"}, status_code=200,
+            background=background_tasks,
+        )

--- a/packages/py-api/py_api/controllers/hackathon/verification_controller.py
+++ b/packages/py-api/py_api/controllers/hackathon/verification_controller.py
@@ -60,7 +60,7 @@ class VerificationController:
             return JSONResponse(content={"message": "No participant found"}, status_code=404)
 
         background_tasks = BackgroundTasks()
-        if decoded_token.get("team_name") is None and decoded_token.get("random_participant") is True:
+        if decoded_token.get("random_participant") is True:
             random_teams = TeamFunctionality.fetch_teams_by_condition(
                 {"team_type": "random"},
             )
@@ -78,8 +78,8 @@ class VerificationController:
                 decoded_token, session, background_tasks, verified_participant, True, jwt_token,
             )
 
-        if decoded_token.get("team_name") and decoded_token.get("random_participant") is False:
-            # A confirmation email is send to the admin along with the invite link
+        else:
+            # A confirmation email is sent to the admin along with the invite link
             jwt_token = JWTFunctionality.create_jwt_token(
                 team_name=decoded_token.get("team_name"), is_invite=True,
             )

--- a/packages/py-api/py_api/controllers/hackathon/verification_controller.py
+++ b/packages/py-api/py_api/controllers/hackathon/verification_controller.py
@@ -1,18 +1,23 @@
 from typing import Any, Dict
 
 from fastapi.responses import JSONResponse
+from py_api.database.database_transaction_handlers import (
+    handle_database_session_transaction,
+)
 from py_api.functionality.hackathon.jwt_base import JWTFunctionality
 from py_api.functionality.hackathon.mailing_functionality import MailingFunctionality
 from py_api.functionality.hackathon.participants_base import ParticipantsFunctionality
 from py_api.functionality.hackathon.teams_base import TeamFunctionality
+from py_api.models import HackathonTeam
 from py_api.models.hackathon_participants_models import UpdateParticipant
-from py_api.services.mailer import send_email_background_task
+from pymongo.client_session import ClientSession
 from starlette.background import BackgroundTasks
 
 
 class VerificationController:
     @classmethod
-    def verify_participants(cls, jwt_token: str) -> JSONResponse | Dict[str, str]:
+    @handle_database_session_transaction
+    def verify_participants(cls, jwt_token: str, session: ClientSession) -> JSONResponse | Dict[str, str]:
         background_tasks = BackgroundTasks()
 
         result = JWTFunctionality.decode_token(jwt_token)
@@ -22,61 +27,125 @@ class VerificationController:
         else:
             return JSONResponse(content=result[0], status_code=result[1])
 
-        team = TeamFunctionality.fetch_team(
-            team_name=decoded_token.get("team_name"),
+        participant = ParticipantsFunctionality.get_participant_by_id(
+            str(decoded_token.get("sub")),
         )
-        if not team:
+        if not participant:
             return JSONResponse(
-                content={
-                    "message": "Cannot verify participant as such team doesn't exist",
-                },
-                status_code=404,
+                content={"message": "Participant with such id does not exist"},
+                status_code=208,
+            )
+
+        if participant.get("is_verified") is True:
+            return JSONResponse(
+                content={"message": "Participant is already verified"},
+                status_code=208,
             )
 
         verified_participant: Dict[str, Any] = ParticipantsFunctionality.update_participant(
             object_id=str(decoded_token.get("sub")), participant=UpdateParticipant(
                 is_verified=True,
-            ),
+            ), session=session,
         )
 
-        if team.is_verified is not True:
-            team.is_verified = True
-            TeamFunctionality.update_team_query_using_dump(
-                team_payload=team.model_dump(),
+        if decoded_token.get("team_name") is None and decoded_token.get("random_participant") is True:
+            new_random_team = cls.create_new_team(
+                new_participant_object_id=str(decoded_token.get("sub")), session=session, generate_random_team=True,
+                team_name=None,
             )
 
-        try:
-            if team.team_type == team.team_type.NORMAL:
-                # A confirmation email is send to the admin along with the invite link
-                jwt_token = JWTFunctionality.create_jwt_token(
-                    team_name=team.team_name, is_invite=True,
-                )
+            # A confirmation email is send to the random participant
+            background_tasks.add_task(
+                MailingFunctionality.send_confirmation_email, email=verified_participant.get(
+                    "email",
+                ),
+                jwt_token=jwt_token,
+                team_name=None,
+                is_admin=False,
+                participant_name=verified_participant.get("first_name"),
+            )
 
-                background_tasks.add_task(
-                    MailingFunctionality.send_confirmation_email, email=verified_participant.get(
-                        "email",
-                    ),
-                    jwt_token=jwt_token,
-                    team_name=verified_participant.get("team_name"),
-                    participant_name=verified_participant.get("first_name"), is_admin=True,
-                )
-
-            else:
-                # A confirmation email is send to the random participant
-                background_tasks.add_task(
-                    MailingFunctionality.send_confirmation_email, email=verified_participant.get(
-                        "email",
-                    ),
-                    jwt_token=jwt_token,
-                    team_name=None,
-                    participant_name=verified_participant.get("first_name"),
-                )
-
-        except Exception as e:
             return JSONResponse(
-                content={"error": str(e)},
-                status_code=500,
+                content={
+                    "message": f"Random participant was successfully verified and has been added to team "
+                               f"{new_random_team.team_name}",
+                },
+                status_code=200,
+                background=background_tasks,
             )
+
+        if decoded_token.get("team_name") and decoded_token.get("random_participant") is False and decoded_token.get(
+                "invite",
+        ) is False:
+            new_team = cls.create_new_team(
+                new_participant_object_id=str(decoded_token.get("sub")), session=session, generate_random_team=False,
+                team_name=decoded_token.get("team_name"),
+            )
+
+            # A confirmation email is send to the admin along with the invite link
+            jwt_token = JWTFunctionality.create_jwt_token(
+                team_name=new_team.team_name, is_invite=True,
+            )
+
+            background_tasks.add_task(
+                MailingFunctionality.send_confirmation_email, email=verified_participant.get(
+                    "email",
+                ),
+                jwt_token=jwt_token,
+                team_name=verified_participant.get("team_name"),
+                participant_name=verified_participant.get("first_name"), is_admin=True,
+            )
+
+            return JSONResponse(
+                content={
+                    "message": f"Admin participant was successfully verified and has been added to team "
+                               f"{new_team.team_name}",
+                },
+                status_code=200,
+                background=background_tasks,
+            )
+
+        # team = TeamFunctionality.fetch_team(
+        #     team_name=decoded_token.get("team_name"),
+        # )
+        # if not team:
+        #     return JSONResponse(
+        #         content={
+        #             "message": "Cannot verify participant as such team doesn't exist",
+        #         },
+        #         status_code=404,
+        #     )
+        #
+        # if team.is_verified is not True:
+        #     team.is_verified = True
+        #     TeamFunctionality.update_team_query_using_dump(
+        #         team_payload=team.model_dump(),
+        #     )
+        #
+        # try:
+        #     if team.team_type == team.team_type.NORMAL:
+        #         # A confirmation email is send to the admin along with the invite link
+        #         jwt_token = JWTFunctionality.create_jwt_token(
+        #             team_name=team.team_name, is_invite=True,
+        #         )
+        #
+        #         background_tasks.add_task(
+        #             MailingFunctionality.send_confirmation_email, email=verified_participant.get(
+        #                 "email",
+        #             ),
+        #             jwt_token=jwt_token,
+        #             team_name=verified_participant.get("team_name"),
+        #             participant_name=verified_participant.get("first_name"), is_admin=True,
+        #         )
+        #
+        #     else:
+        # # A confirmation email is send to the random participant
+        #
+        # except Exception as e:
+        #     return JSONResponse(
+        #         content={"error": str(e)},
+        #         status_code=500,
+        #     )
 
         return JSONResponse(
             content={"message": "Participant was successfully verified"}, status_code=200,
@@ -86,3 +155,23 @@ class VerificationController:
     @classmethod
     def test_controller(cls, team_name: str) -> Any:
         return {"token": JWTFunctionality.create_jwt_token(team_name)}
+
+    @classmethod
+    def create_new_team(
+        cls, new_participant_object_id: str, session: ClientSession,
+        generate_random_team: bool, team_name: str | None = None,
+    ) -> HackathonTeam:
+        """
+        Creates a new random team with the participant and inserts it into the database
+
+        Returns a new team object"""
+
+        new_team_obj = TeamFunctionality.create_team_object_with_first_participant(
+            user_id=new_participant_object_id,
+            team_name=team_name,
+            generate_random_team=generate_random_team,
+        )
+
+        TeamFunctionality.insert_team(new_team_obj, session)
+
+        return new_team_obj

--- a/packages/py-api/py_api/controllers/hackathon/verification_controller.py
+++ b/packages/py-api/py_api/controllers/hackathon/verification_controller.py
@@ -4,12 +4,15 @@ from fastapi.responses import JSONResponse
 from py_api.database.database_transaction_handlers import (
     handle_database_session_transaction,
 )
-from py_api.functionality.hackathon.jwt_base import JWTFunctionality
+from py_api.functionality.hackathon.jwt_base import JWTFunctionality, JWTType
 from py_api.functionality.hackathon.mailing_functionality import MailingFunctionality
 from py_api.functionality.hackathon.participants_base import ParticipantsFunctionality
 from py_api.functionality.hackathon.teams_base import TeamFunctionality
 from py_api.models import HackathonTeam
-from py_api.models.hackathon_participants_models import UpdateParticipant
+from py_api.models.hackathon_participants_models import (
+    NewParticipant,
+    UpdateParticipant,
+)
 from pymongo.client_session import ClientSession
 from starlette.background import BackgroundTasks
 
@@ -17,7 +20,7 @@ from starlette.background import BackgroundTasks
 class VerificationController:
     @classmethod
     @handle_database_session_transaction
-    def verify_participants(cls, jwt_token: str, session: ClientSession) -> JSONResponse | Dict[str, str]:
+    def verify_participants(cls, jwt_token: str, session: ClientSession) -> JSONResponse:
         background_tasks = BackgroundTasks()
 
         result = JWTFunctionality.decode_token(jwt_token)
@@ -49,117 +52,85 @@ class VerificationController:
         )
 
         if decoded_token.get("team_name") is None and decoded_token.get("random_participant") is True:
-            new_random_team = cls.create_new_team(
-                new_participant_object_id=str(decoded_token.get("sub")), session=session, generate_random_team=True,
-                team_name=None,
+            # Fetch the teams of type random
+            random_teams = TeamFunctionality.fetch_teams_by_condition(
+                {"team_type": "random"},
             )
 
-            # A confirmation email is send to the random participant
-            background_tasks.add_task(
-                MailingFunctionality.send_confirmation_email, email=verified_participant.get(
-                    "email",
-                ),
-                jwt_token=jwt_token,
-                team_name=None,
-                is_admin=False,
-                participant_name=verified_participant.get("first_name"),
-            )
+            # Find the teams which can accept a new participant and add it if there is space
+            for team in random_teams:
+                if len(team.team_members) < 6:
+                    return cls.add_participant_to_existing_team(
+                        verified_participant, team, session,
+                        decoded_token, background_tasks, jwt_token,
+                    )
 
-            return JSONResponse(
-                content={
-                    "message": f"Random participant was successfully verified and has been added to team "
-                               f"{new_random_team.team_name}",
-                },
-                status_code=200,
-                background=background_tasks,
+            # Create a new random team if needed
+            return cls.create_team_and_send_email(
+                decoded_token, session, background_tasks, verified_participant, True, jwt_token,
             )
 
         if decoded_token.get("team_name") and decoded_token.get("random_participant") is False and decoded_token.get(
                 "invite",
         ) is False:
-            new_team = cls.create_new_team(
-                new_participant_object_id=str(decoded_token.get("sub")), session=session, generate_random_team=False,
-                team_name=decoded_token.get("team_name"),
-            )
-
             # A confirmation email is send to the admin along with the invite link
             jwt_token = JWTFunctionality.create_jwt_token(
-                team_name=new_team.team_name, is_invite=True,
+                team_name=decoded_token.get("team_name"), is_invite=True,
+            )
+            return cls.create_team_and_send_email(
+                decoded_token, session, background_tasks, verified_participant, False, jwt_token,
             )
 
-            background_tasks.add_task(
-                MailingFunctionality.send_confirmation_email, email=verified_participant.get(
-                    "email",
-                ),
-                jwt_token=jwt_token,
-                team_name=verified_participant.get("team_name"),
-                participant_name=verified_participant.get("first_name"), is_admin=True,
-            )
+    @classmethod
+    def create_team_and_send_email(
+        cls, decoded_token: JWTType, session: ClientSession,
+        background_tasks: BackgroundTasks,
+        verified_participant: Dict[str, Any], generate_random_team: bool,
+        jwt_token: str,
+    ) -> JSONResponse:
+        new_team = cls.create_new_team(
+            new_participant_object_id=str(decoded_token.get("sub")), session=session,
+            generate_random_team=generate_random_team,
+            team_name=decoded_token.get("team_name"),
+        )
 
-            return JSONResponse(
-                content={
-                    "message": f"Admin participant was successfully verified and has been added to team "
-                               f"{new_team.team_name}",
-                },
-                status_code=200,
-                background=background_tasks,
+        if generate_random_team:
+            cls.send_confirmation_email(
+                background_tasks, verified_participant, jwt_token, None,
             )
-
-        # team = TeamFunctionality.fetch_team(
-        #     team_name=decoded_token.get("team_name"),
-        # )
-        # if not team:
-        #     return JSONResponse(
-        #         content={
-        #             "message": "Cannot verify participant as such team doesn't exist",
-        #         },
-        #         status_code=404,
-        #     )
-        #
-        # if team.is_verified is not True:
-        #     team.is_verified = True
-        #     TeamFunctionality.update_team_query_using_dump(
-        #         team_payload=team.model_dump(),
-        #     )
-        #
-        # try:
-        #     if team.team_type == team.team_type.NORMAL:
-        #         # A confirmation email is send to the admin along with the invite link
-        #         jwt_token = JWTFunctionality.create_jwt_token(
-        #             team_name=team.team_name, is_invite=True,
-        #         )
-        #
-        #         background_tasks.add_task(
-        #             MailingFunctionality.send_confirmation_email, email=verified_participant.get(
-        #                 "email",
-        #             ),
-        #             jwt_token=jwt_token,
-        #             team_name=verified_participant.get("team_name"),
-        #             participant_name=verified_participant.get("first_name"), is_admin=True,
-        #         )
-        #
-        #     else:
-        # # A confirmation email is send to the random participant
-        #
-        # except Exception as e:
-        #     return JSONResponse(
-        #         content={"error": str(e)},
-        #         status_code=500,
-        #     )
+        else:
+            cls.send_confirmation_email(
+                background_tasks, verified_participant, jwt_token, new_team.team_name,
+            )
 
         return JSONResponse(
-            content={"message": "Participant was successfully verified"}, status_code=200,
+            content={
+                "message": f"Participant was successfully verified and has been added to team "
+                           f"{new_team.team_name}",
+            },
+            status_code=200,
             background=background_tasks,
         )
 
     @classmethod
-    def test_controller(cls, team_name: str) -> Any:
-        return {"token": JWTFunctionality.create_jwt_token(team_name)}
+    def send_confirmation_email(
+        cls, background_tasks: BackgroundTasks, verified_participant: Dict[str, Any],
+        jwt_token: str,
+        team_name: str | None,
+    ) -> None:
+        background_tasks.add_task(
+            MailingFunctionality.send_confirmation_email, email=verified_participant.get(
+                "email",
+            ),
+            jwt_token=jwt_token,
+            team_name=team_name,
+            participant_name=verified_participant.get("first_name"), is_admin=verified_participant.get("is_admin"),
+        )
 
     @classmethod
     def create_new_team(
-        cls, new_participant_object_id: str, session: ClientSession,
-        generate_random_team: bool, team_name: str | None = None,
+            cls, new_participant_object_id: str, session: ClientSession,
+            generate_random_team: bool, team_name: str | None = None,
     ) -> HackathonTeam:
         """
         Creates a new random team with the participant and inserts it into the database
@@ -175,3 +146,27 @@ class VerificationController:
         TeamFunctionality.insert_team(new_team_obj, session)
 
         return new_team_obj
+
+    @classmethod
+    def add_participant_to_existing_team(
+        cls, participant: Dict[str, Any], existing_team: HackathonTeam,
+        session: ClientSession, decoded_token: JWTType,
+        background_tasks: BackgroundTasks, jwt_token: str,
+        is_invite: bool = False,
+    ) -> JSONResponse:
+
+        result = TeamFunctionality.add_participant_to_team_object(
+            existing_team.team_name, decoded_token["sub"],
+        )
+
+        if not isinstance(result, HackathonTeam):
+            return JSONResponse(content=result[0], status_code=result[1])
+
+        existing_team = TeamFunctionality.update_team_query_using_dump(
+            result.model_dump(), session=session,
+        )
+        cls.send_confirmation_email(
+            background_tasks, participant, jwt_token, None,
+        )
+
+        return JSONResponse(content=existing_team.model_dump(), status_code=200, background=background_tasks)

--- a/packages/py-api/py_api/database/database_transaction_handlers.py
+++ b/packages/py-api/py_api/database/database_transaction_handlers.py
@@ -1,20 +1,18 @@
 from functools import wraps
 from typing import Any, Callable
 
-from fastapi.responses import JSONResponse
 from py_api.database.initialize import client
 
 
+# https://pymongo.readthedocs.io/en/stable/api/pymongo/client_session.html
 def handle_database_session_transaction(func: Callable[..., Any]) -> Callable[..., Any]:
     @wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
-        try:
-            # Assuming `client` is an instance of MongoClient
-            with client.start_session() as session:
-                with session.start_transaction():
-                    return func(*args, session=session, **kwargs)
-
-        except Exception as e:
-            return JSONResponse(content={"error": str(e)}, status_code=500)
+        """Upon normal completion of with session.start_transaction() block, the transaction automatically
+        calls ClientSession.commit_transaction().
+        If the block exits with an exception, the transaction automatically calls ClientSession.abort_transaction()."""
+        with client.start_session() as session:
+            with session.start_transaction():
+                return func(*args, session=session, **kwargs)
 
     return wrapper

--- a/packages/py-api/py_api/database/initialize.py
+++ b/packages/py-api/py_api/database/initialize.py
@@ -1,4 +1,4 @@
-from py_api.environment import MONGO_URI
+from py_api.environment import IS_OFFLINE, MONGO_URI
 from pymongo import MongoClient
 
 # * How to use - https://pymongo.readthedocs.io/en/stable/tutorial.html
@@ -18,7 +18,13 @@ su_col = client["ShortenedUrlsDB"].shortened_urls
 q_col = client["questionnaires"].questions
 a_col = client["questionnaires"].answers
 
-# * use these collections when working within the Teams controller
-t_col = client['hackathon'].teams
-# * use these collections when working within the Hackathon_Participants controller
-participants_col = client["hackathon"].participants
+if not IS_OFFLINE:
+    # * use these collections when working within the Teams controller
+    t_col = client['hackathon'].teams
+    # * use these collections when working within the Hackathon_Participants controller
+    participants_col = client["hackathon"].participants
+else:
+    # * use these collections when working within the Teams controller
+    t_col = client['hackathon'].dev_teams
+    # * use these collections when working within the Hackathon_Participants controller
+    participants_col = client["hackathon"].dev_participants

--- a/packages/py-api/py_api/database/initialize.py
+++ b/packages/py-api/py_api/database/initialize.py
@@ -1,4 +1,4 @@
-from py_api.environment import IS_OFFLINE, MONGO_URI
+from py_api.environment import DOCK_ENV, IS_OFFLINE, MONGO_URI
 from pymongo import MongoClient
 
 # * How to use - https://pymongo.readthedocs.io/en/stable/tutorial.html
@@ -18,7 +18,7 @@ su_col = client["ShortenedUrlsDB"].shortened_urls
 q_col = client["questionnaires"].questions
 a_col = client["questionnaires"].answers
 
-if not IS_OFFLINE:
+if DOCK_ENV == 'PROD':
     # * use these collections when working within the Teams controller
     t_col = client['hackathon'].teams
     # * use these collections when working within the Hackathon_Participants controller

--- a/packages/py-api/py_api/environment.py
+++ b/packages/py-api/py_api/environment.py
@@ -15,7 +15,7 @@ SECRET_KEY = getenv("SECRET_KEY")
 HUB_MAIL = getenv("HUB_MAIL")
 HUB_PSW = getenv("HUB_PSW")
 HUB_WEB_URL = getenv("HUB_WEB_URL", "")
-
+DOCK_ENV = getenv("DOCK_ENV", "")
 
 OFFLINE_TOKEN = "OFFLINE_TOKEN"
 

--- a/packages/py-api/py_api/functionality/hackathon/jwt_base.py
+++ b/packages/py-api/py_api/functionality/hackathon/jwt_base.py
@@ -21,7 +21,7 @@ class JWTFunctionality:
             "sub": participant_obj_id,
             "team_name": team_name,
             "invite": is_invite,
-            "exp": datetime.utcnow() + timedelta(days=30 if is_invite else 2),
+            "exp": datetime.utcnow() + timedelta(days=30 if is_invite else 1),
         }
 
         return str(encode(payload, SECRET_KEY, algorithm="HS256"))

--- a/packages/py-api/py_api/functionality/hackathon/jwt_base.py
+++ b/packages/py-api/py_api/functionality/hackathon/jwt_base.py
@@ -11,7 +11,10 @@ from jwt import (
 from py_api.environment import HUB_WEB_URL, IS_OFFLINE, SECRET_KEY
 
 JWTType = TypedDict(
-    'JWTType', {'sub': str, 'team_name': str, 'invite': bool, 'exp': datetime},
+    'JWTType', {
+        'sub': str, 'team_name': str, 'invite': bool,
+        'random_participant': bool, 'exp': datetime,
+    },
 )
 
 
@@ -67,9 +70,9 @@ class JWTFunctionality:
 
         if for_frontend:
             if is_invite:
-                url = f"{domain}hackaubg?jwt_token={jwt_token}"
+                url = f"{domain}/hackaubg?jwt_token={jwt_token}"
             else:
-                url = f"{domain}hackaubg/verify?jwt_token={jwt_token}"
+                url = f"{domain}/hackaubg/verify?jwt_token={jwt_token}"
 
         elif is_invite:
             url = f"{domain}/v2/hackathon/participants?jwt_token={jwt_token}"

--- a/packages/py-api/py_api/functionality/hackathon/jwt_base.py
+++ b/packages/py-api/py_api/functionality/hackathon/jwt_base.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import Any, Dict, Tuple
+from typing import Dict, Tuple, TypedDict, cast
 
 from jwt import (
     DecodeError,
@@ -10,27 +10,35 @@ from jwt import (
 )
 from py_api.environment import HUB_WEB_URL, IS_OFFLINE, SECRET_KEY
 
+JWTType = TypedDict(
+    'JWTType', {'sub': str, 'team_name': str, 'invite': bool, 'exp': datetime},
+)
+
 
 class JWTFunctionality:
 
     @classmethod
     def create_jwt_token(
             cls, participant_obj_id: str | None = None, team_name: str | None = None,
-            is_invite: bool = False, ) -> str:
+            is_invite: bool = False, is_participant_random: bool = False,
+    ) -> str:
         payload = {
             "sub": participant_obj_id,
             "team_name": team_name,
             "invite": is_invite,
+            "random_participant": is_participant_random,
             "exp": datetime.utcnow() + timedelta(days=30 if is_invite else 1),
         }
 
         return str(encode(payload, SECRET_KEY, algorithm="HS256"))
 
     @classmethod
-    def decode_token(cls, jwt_token: str, is_invite: bool = False) -> Dict[str, Any] | Tuple[Dict[str, str], int]:
+    def decode_token(cls, jwt_token: str, is_invite: bool = False) -> JWTType | Tuple[Dict[str, str], int]:
         try:
-            decoded_token: Dict[str, Any] = decode(
-                jwt_token, SECRET_KEY, algorithms=["HS256"],
+            decoded_token = cast(
+                JWTType, decode(
+                    jwt_token, SECRET_KEY, algorithms=["HS256"],
+                ),
             )
             return decoded_token
 

--- a/packages/py-api/py_api/functionality/hackathon/participants_base.py
+++ b/packages/py-api/py_api/functionality/hackathon/participants_base.py
@@ -22,7 +22,10 @@ class ParticipantsFunctionality:
         return False
 
     @classmethod
-    def insert_participant(cls, participant: NewParticipant, session: ClientSession | None = None) -> results.InsertOneResult:
+    def insert_participant(
+        cls, participant: NewParticipant,
+        session: ClientSession | None = None,
+    ) -> results.InsertOneResult:
         if session:
             return cls.pcol.insert_one(participant.model_dump(), session=session)
 
@@ -43,17 +46,17 @@ class ParticipantsFunctionality:
         return cls.pcol.find_one({"_id": ObjectId(object_id)})
 
     @classmethod
-    def update_participant(cls, object_id: str, participant: UpdateParticipant | NewParticipant) -> Any:
+    def update_participant(
+        cls, object_id: str, participant: UpdateParticipant | NewParticipant,
+        session: ClientSession,
+    ) -> Any:
         obj = {
             key: value for key, value in participant.model_dump().items() if
             value is not None
         }
-
-        with client.start_session() as session:
-            with session.start_transaction():
-                return cls.pcol.find_one_and_update(
-                    {"_id": ObjectId(object_id)}, {"$set": obj}, return_document=True,
-                )
+        return cls.pcol.find_one_and_update(
+            {"_id": ObjectId(object_id)}, {"$set": obj}, return_document=True, session=session,
+        )
 
     @classmethod
     def remove_participant_from_team(cls, participant_id: str, team_name: str) -> Tuple[Dict[str, str], int]:

--- a/packages/py-api/py_api/functionality/hackathon/teams_base.py
+++ b/packages/py-api/py_api/functionality/hackathon/teams_base.py
@@ -13,10 +13,10 @@ from pymongo.client_session import ClientSession
 class TeamFunctionality:
 
     @classmethod
-    def create_team_object_with_admin(
+    def create_team_object_with_first_participant(
             cls, user_id: str,
             team_name: str | None = None, generate_random_team: bool = False,
-    ) -> HackathonTeam | None:
+    ) -> HackathonTeam:
         """ creates a new HackathonTeam object without inserting it in the database """
 
         team_type = TeamType.NORMAL
@@ -26,16 +26,12 @@ class TeamFunctionality:
             team_type = TeamType.RANDOM
             team_name = cls.generate_random_team_name()
 
-        if cls.fetch_team(team_name=team_name):
-            # Team with such name already exists
-            return None
-
-        # Upon team initialization, we need at least one team member who is considered the admin
+        # Upon team initialization, we need at least one team member
         team_members_ids = [user_id]
 
         new_team = HackathonTeam(
             team_name=team_name,
-            team_type=team_type, team_members=team_members_ids, is_verified=False,
+            team_type=team_type, team_members=team_members_ids, is_verified=True,
         )
 
         return new_team

--- a/packages/py-api/py_api/functionality/hackathon/teams_base.py
+++ b/packages/py-api/py_api/functionality/hackathon/teams_base.py
@@ -141,4 +141,5 @@ class TeamFunctionality:
 
     @classmethod
     def get_count_of_teams(cls) -> int:
+        """Counts the number of verified teams in the database"""
         return len(cls.fetch_teams_by_condition({"is_verified": True}))

--- a/packages/py-api/py_api/middleware/auth.py
+++ b/packages/py-api/py_api/middleware/auth.py
@@ -23,7 +23,7 @@ logger = getLogger(__name__)
 class AuthMiddleware:
     """Utility class for easily initializing all authentication middleware"""
     _BYPASSED_ENDPOINTS: Final = {
-        "/health": ["GET"], "/routes": ["GET"], "/fswitches": ["GET"], "/hackathon/verify": ["GET"],
+        "/health": ["GET"], "/routes": ["GET"], "/fswitches": ["GET"], "/hackathon/verify": ["POST"],
         "/hackathon/participants": ["POST"],
     }
 

--- a/packages/py-api/py_api/models/hackathon_participants_models.py
+++ b/packages/py-api/py_api/models/hackathon_participants_models.py
@@ -58,7 +58,7 @@ class NewParticipant(BaseModel):
             raise ValueError("share_info_with_sponsors shall be true")
         return value
 
-    @field_validator('tshirt_size', mode='before')
+    @field_validator('tshirt_size', 'team_name', mode='before')
     def convert_empty_string_to_none(cls, value: str) -> str | None:
         return None if value == "" else value
 
@@ -82,6 +82,6 @@ class UpdateParticipant(BaseModel):
     has_previous_coding_experience: Optional[bool] = None
     share_info_with_sponsors: Optional[bool] = True
 
-    @field_validator('tshirt_size', mode='before')
+    @field_validator('tshirt_size', 'team_name', mode='before')
     def convert_empty_string_to_none(cls, value: str) -> str | None:
         return None if value == "" else value

--- a/packages/py-api/py_api/routes/hackathon/verification_routes.py
+++ b/packages/py-api/py_api/routes/hackathon/verification_routes.py
@@ -1,6 +1,4 @@
-from typing import Any
-
-from fastapi import APIRouter, Request
+from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 from py_api.controllers.hackathon.verification_controller import (
     VerificationController as c,
@@ -9,11 +7,6 @@ from py_api.controllers.hackathon.verification_controller import (
 router = APIRouter(prefix="/hackathon/verify")
 
 
-@router.get("/participant")
-async def verify_admin(jwt_token: str) -> JSONResponse:
+@router.post("/participant")
+async def verify_participant(jwt_token: str) -> JSONResponse:
     return c.verify_participants(jwt_token)
-
-
-@router.get("/test")
-def verify_url(team_name: str) -> Any:
-    return c.test_controller(team_name=team_name)

--- a/packages/web/src/components/spa/HackAUBG/VerifyAccountPop/VerifyAccount.jsx
+++ b/packages/web/src/components/spa/HackAUBG/VerifyAccountPop/VerifyAccount.jsx
@@ -22,7 +22,7 @@ export const VerifyAccount = ({ className, onSuccess }) => {
     const handleVerifyClick = () => {
         setLoading(true);
         axios({
-            method: 'get',
+            method: 'post',
             url: verifyURL + `?jwt_token=${jwtToken}`,
         })
             .then(() => {


### PR DESCRIPTION
## Refactored the whole logic for the fifth time. 
* Now teams are created only when the participant verifies their email
* Random participants are added to existing random teams on email verification
* There are no more admins of random teams as it was confusing.
* The logic for creating a participant via an invite link stays the same.
* Changed method for the verify endpoint from `GET `to `POST`