### PR TITLE
Save the timestamps in the database

### DIFF
--- a/services/py-api/src/database/model/participant_model.py
+++ b/services/py-api/src/database/model/participant_model.py
@@ -17,23 +17,23 @@ class Participant(Base):
     def dump_as_mongo_db_document(self) -> Dict[str, Any]:
         return {
             "_id": self.id,
-            "created_at": self.created_at,
-            "updated_at": self.updated_at,
             "name": self.name,
             "email": self.email,
             "is_admin": self.is_admin,
             "email_verified": self.email_verified,
             "team_id": self.team_id,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
         }
 
     def dump_as_json(self) -> Dict[str, Any]:
         return {
             "id": str(self.id),
-            "created_at": self.created_at.strftime("%Y-%m-%d %H:%M:%S"),
-            "updated_at": self.updated_at.strftime("%Y-%m-%d %H:%M:%S"),
             "name": self.name,
             "email": self.email,
             "is_admin": self.is_admin,
             "email_verified": self.email_verified,
             "team_id": str(self.team_id),
+            "created_at": self.created_at.strftime("%Y-%m-%d %H:%M:%S"),
+            "updated_at": self.updated_at.strftime("%Y-%m-%d %H:%M:%S"),
         }

--- a/services/py-api/src/database/model/participant_model.py
+++ b/services/py-api/src/database/model/participant_model.py
@@ -17,6 +17,8 @@ class Participant(Base):
     def dump_as_mongo_db_document(self) -> Dict[str, Any]:
         return {
             "_id": self.id,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
             "name": self.name,
             "email": self.email,
             "is_admin": self.is_admin,
@@ -27,6 +29,8 @@ class Participant(Base):
     def dump_as_json(self) -> Dict[str, Any]:
         return {
             "id": str(self.id),
+            "created_at": self.created_at.strftime("%Y-%m-%d %H:%M:%S"),
+            "updated_at": self.updated_at.strftime("%Y-%m-%d %H:%M:%S"),
             "name": self.name,
             "email": self.email,
             "is_admin": self.is_admin,

--- a/services/py-api/src/database/model/team_model.py
+++ b/services/py-api/src/database/model/team_model.py
@@ -12,17 +12,17 @@ class Team(Base):
     def dump_as_json(self) -> Dict[str, Any]:
         return {
             "id": str(self.id),
-            "created_at": self.created_at.strftime("%Y-%m-%d %H:%M:%S"),
-            "updated_at": self.updated_at.strftime("%Y-%m-%d %H:%M:%S"),
             "name": self.name,
             "is_verified": self.is_verified,
+            "created_at": self.created_at.strftime("%Y-%m-%d %H:%M:%S"),
+            "updated_at": self.updated_at.strftime("%Y-%m-%d %H:%M:%S"),
         }
 
     def dump_as_mongo_db_document(self) -> Dict[str, Any]:
         return {
             "_id": self.id,
-            "created_at": self.created_at,
-            "updated_at": self.updated_at,
             "name": self.name,
             "is_verified": self.is_verified,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
         }

--- a/services/py-api/src/database/model/team_model.py
+++ b/services/py-api/src/database/model/team_model.py
@@ -10,7 +10,19 @@ class Team(Base):
     is_verified: bool = field(default=False)
 
     def dump_as_json(self) -> Dict[str, Any]:
-        return {"id": str(self.id), "name": self.name, "is_verified": self.is_verified}
+        return {
+            "id": str(self.id),
+            "created_at": self.created_at.strftime("%Y-%m-%d %H:%M:%S"),
+            "updated_at": self.updated_at.strftime("%Y-%m-%d %H:%M:%S"),
+            "name": self.name,
+            "is_verified": self.is_verified,
+        }
 
     def dump_as_mongo_db_document(self) -> Dict[str, Any]:
-        return {"_id": self.id, "name": self.name, "is_verified": self.is_verified}
+        return {
+            "_id": self.id,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "name": self.name,
+            "is_verified": self.is_verified,
+        }


### PR DESCRIPTION
#Quick fix
The methods in the serializing methods in the participant and team models did not include the timestamps when building JSON object and the mongoDB document. The base model correctly generated by default a timestamp and an objectID, however we were not using them. 

## How to verify:

- [ ] Start the backend server

- [ ] Use the create endpoint to create a new admin. 

- [ ] Check the response

