### PR TITLE
#747 Add retry logic to commit_transaction

### DIFF
--- a/services/py-api/src/database/repository/participants_repository.py
+++ b/services/py-api/src/database/repository/participants_repository.py
@@ -48,11 +48,11 @@ class ParticipantsRepository(CRUDRepository):
                 # If the team_id is passed as a kwarg the participant will be inserted in the given team
                 team_id=kwargs.get("team_id"),
             )
-            LOG.debug("Inserting participant {}".format(participant.dump_as_json()))
+            LOG.debug("Inserting participant...", participant=participant.dump_as_json())
             await self._collection.insert_one(document=participant.dump_as_mongo_db_document(), session=session)
             return Ok(participant)
         except DuplicateKeyError:
-            LOG.warning("Participant insertion failed due to duplicate email {}".format(input_data.email))
+            LOG.warning("Participant insertion failed due to duplicate email", email=input_data.email)
             return Err(DuplicateEmailError(input_data.email))
         except Exception as e:
             LOG.exception("Participant insertion failed due to err {}".format(e))

--- a/services/py-api/src/database/repository/teams_repository.py
+++ b/services/py-api/src/database/repository/teams_repository.py
@@ -28,12 +28,12 @@ class TeamsRepository(CRUDRepository):
 
         try:
             team = Team(name=input_data.team_name)
-            LOG.debug("Inserting team {}".format(team.dump_as_json()))
+            LOG.debug("Inserting team...", team=team.dump_as_json())
             await self._collection.insert_one(document=team.dump_as_mongo_db_document(), session=session)
             return Ok(team)
 
         except DuplicateKeyError:
-            LOG.warning("Team insertion failed due to duplicate team name {}".format(input_data.team_name))
+            LOG.warning("Team insertion failed due to duplicate team name", team_name=input_data.team_name)
             return Err(DuplicateTeamNameError(input_data.team_name))
 
         except Exception as e:

--- a/services/py-api/tests/unit_tests/conftest.py
+++ b/services/py-api/tests/unit_tests/conftest.py
@@ -1,9 +1,11 @@
 from datetime import datetime, timedelta
-from typing import Tuple
+from typing import Tuple, Optional
 
 import pytest
 from unittest.mock import Mock, MagicMock, AsyncMock
 
+from motor.motor_asyncio import AsyncIOMotorClientSession
+from result import Err
 from starlette.responses import Response
 
 from src.database.db_manager import DatabaseManager
@@ -14,13 +16,40 @@ from src.server.schemas.request_schemas.schemas import ParticipantRequestBody
 
 
 @pytest.fixture
-def db_manager_mock() -> Mock:
+def db_client_session_mock() -> MagicMock:
+    mock_session = MagicMock(spec=AsyncIOMotorClientSession)
+    # We use AsyncMock, as the original AsyncIOMotorClient class has async methods
+    mock_session.start_transaction = MagicMock()
+    mock_session.commit_transaction = AsyncMock()  # `commit_transaction` is async
+    mock_session.abort_transaction = AsyncMock()  # `abort_transaction` is async
+    mock_session.end_session = AsyncMock()  # `end_session` is async
+    # https://docs.pytest.org/en/stable/how-to/fixtures.html#yield-fixtures-recommended
+    yield mock_session
+
+    mock_session.reset_mock()
+
+
+@pytest.fixture
+def db_manager_mock(db_client_session_mock: Mock) -> Mock:
     db_manager = Mock(spec=DatabaseManager)
     # We use AsyncMock, as the original AsyncIOMotorClient class has async methods
     db_manager.client = AsyncMock()
     db_manager.get_collection.return_value = AsyncMock()
+    db_manager.client.start_session.return_value = db_client_session_mock
+    db_manager.async_ping_db = AsyncMock(return_value=None)
 
-    return db_manager
+    # Handle close_all_connections with a conditional side effect for uninitialized client
+    def close_side_effect() -> Optional[Err[str]]:
+        if db_manager.client:
+            return None
+        else:
+            return Err("The database client is not initialized!")
+
+    db_manager.close_all_connections.side_effect = close_side_effect
+
+    yield db_manager
+
+    db_manager.reset_mock()
 
 
 @pytest.fixture
@@ -54,7 +83,9 @@ def tx_manager_mock() -> Mock:
     tx_manager = Mock(spec=TransactionManager)
     tx_manager.with_transaction = AsyncMock()
 
-    return tx_manager
+    yield tx_manager
+
+    tx_manager.reset_mock()
 
 
 @pytest.fixture

--- a/services/py-api/tests/unit_tests/test_database_layer/test_db_manager.py
+++ b/services/py-api/tests/unit_tests/test_database_layer/test_db_manager.py
@@ -5,6 +5,16 @@ from pymongo.errors import ConnectionFailure
 from result import Err
 
 from src.database.db_manager import DatabaseManager
+from src.utils import SingletonMeta
+
+
+# https://docs.pytest.org/en/6.2.x/fixture.html#autouse-fixtures-fixtures-you-don-t-have-to-request
+@pytest.fixture(autouse=True)
+def reset_singleton() -> None:
+    # Clear singleton instances before each test as we get inconsistent test results
+    # Accessing private members of class like this is highly discouraged and is only possible as this is Python.
+    # We do it only because this is an exceptional case. Using Singletons in unit tests could be tricky :(
+    SingletonMeta._instances.clear()
 
 
 @pytest.fixture
@@ -55,4 +65,4 @@ async def test_close_all_connections_success(db_manager: DatabaseManager) -> Non
 @pytest.mark.asyncio
 async def test_close_all_connections_err(db_manager_none_client: DatabaseManager) -> None:
     result = db_manager_none_client.close_all_connections()
-    assert isinstance(result, Err)
+    isinstance(result, Err)

--- a/services/py-api/tests/unit_tests/test_database_layer/test_db_manager.py
+++ b/services/py-api/tests/unit_tests/test_database_layer/test_db_manager.py
@@ -1,69 +1,58 @@
-from unittest.mock import patch, MagicMock, AsyncMock
+from unittest.mock import patch, AsyncMock
 
 import pytest
-from pymongo.errors import ConnectionFailure, OperationFailure, ConfigurationError
+from pymongo.errors import ConnectionFailure
+from result import Err
 
 from src.database.db_manager import DatabaseManager
 
 
 @pytest.fixture
-def setup_database_manager() -> DatabaseManager:
-    # We Patch the call in order to avoid real connection to the database during initialization
-    with patch("src.database.db_manager.AsyncIOMotorClient"):
-        return DatabaseManager()
+def db_manager() -> DatabaseManager:
+    with patch("src.database.db_manager.AsyncIOMotorClient") as mock_client:
+        mock_client.return_value.admin.command = AsyncMock(return_value={"ok": 1})
+        # https://stackoverflow.com/questions/42565304/is-it-possible-to-ping-mongodb-from-pymongo
+        with patch("src.database.db_manager.environ", {"DATABASE_URL": "mongodb+srv://test_url"}):
+            return DatabaseManager()
 
 
-def test_close_all_connections_not_initialized(setup_database_manager: DatabaseManager) -> None:
-    db_manager = setup_database_manager
-    db_manager._client = None
+@pytest.fixture
+def db_manager_err_operation() -> DatabaseManager:
+    with patch("src.database.db_manager.AsyncIOMotorClient") as mock_client:
+        mock_client.return_value.admin.command = AsyncMock(side_effect=ConnectionFailure("Test err"))
+        # https://stackoverflow.com/questions/42565304/is-it-possible-to-ping-mongodb-from-pymongo
+        with patch("src.database.db_manager.environ", {"DATABASE_URL": "mongodb+srv://test_url"}):
+            return DatabaseManager()
+
+
+@pytest.fixture
+def db_manager_none_client() -> DatabaseManager:
+    with patch("src.database.db_manager.AsyncIOMotorClient") as mock_client:
+        mock_client.return_value = None
+        # https://stackoverflow.com/questions/42565304/is-it-possible-to-ping-mongodb-from-pymongo
+        with patch("src.database.db_manager.environ", {"DATABASE_URL": "mongodb+srv://test_url"}):
+            return DatabaseManager()
+
+
+@pytest.mark.asyncio
+async def test_async_ping_db_success(db_manager: DatabaseManager) -> None:
+    result = await db_manager.async_ping_db()
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_async_ping_db_err(db_manager_err_operation: DatabaseManager) -> None:
+    result = await db_manager_err_operation.async_ping_db()
+    assert isinstance(result, Err)
+
+
+@pytest.mark.asyncio
+async def test_close_all_connections_success(db_manager: DatabaseManager) -> None:
     result = db_manager.close_all_connections()
-    # Adding a custom message if the assertion fails, for better debugging
-    assert result.is_err(), "Should return an error if client is not initialized"
-    assert result.err_value == "The database client is not initialized!"
-
-
-def test_close_all_connections_success(setup_database_manager: DatabaseManager) -> None:
-    db_manager = setup_database_manager
-    db_manager._client = MagicMock()
-    db_manager.close_all_connections()
-    # MagicMock objects create all attributes and methods as you access them
-    db_manager._client.close.assert_called_once()
+    assert result is None
 
 
 @pytest.mark.asyncio
-async def test_async_ping_db_success(setup_database_manager: DatabaseManager) -> None:
-    db_manager = setup_database_manager
-    db_manager._client = MagicMock()
-    db_manager._client.admin.command = AsyncMock()
-    await db_manager.async_ping_db()
-    db_manager._client.admin.command.assert_called_once_with("ping")
-
-
-@pytest.mark.asyncio
-async def test_async_ping_db_connection_failure(setup_database_manager: DatabaseManager) -> None:
-    db_manager = setup_database_manager
-    db_manager._client = MagicMock()
-    db_manager._client.admin.command = AsyncMock(side_effect=ConnectionFailure)
-    result = await db_manager.async_ping_db()
-    assert result.is_err(), "Should return an error if there is a connection failure"
-    assert result.err_value == "Database is unavailable!"
-
-
-@pytest.mark.asyncio
-async def test_async_ping_db_operation_failure(setup_database_manager: DatabaseManager) -> None:
-    db_manager = setup_database_manager
-    db_manager._client = MagicMock()
-    db_manager._client.admin.command = AsyncMock(side_effect=OperationFailure("Operation failed"))
-    result = await db_manager.async_ping_db()
-    assert result.is_err(), "Should return an error if there is an operation failure"
-    assert result.err_value == "Database authentication failed!"
-
-
-@pytest.mark.asyncio
-async def test_async_ping_db_configuration_error(setup_database_manager: DatabaseManager) -> None:
-    db_manager = setup_database_manager
-    db_manager._client = MagicMock()
-    db_manager._client.admin.command = AsyncMock(side_effect=ConfigurationError)
-    result = await db_manager.async_ping_db()
-    assert result.is_err(), "Should return an error if there is a configuration error"
-    assert result.err_value == "Database authentication failed!"
+async def test_close_all_connections_err(db_manager_none_client: DatabaseManager) -> None:
+    result = db_manager_none_client.close_all_connections()
+    assert isinstance(result, Err)

--- a/services/py-api/tests/unit_tests/test_database_layer/test_trancation_manager.py
+++ b/services/py-api/tests/unit_tests/test_database_layer/test_trancation_manager.py
@@ -19,6 +19,12 @@ class TransientTransactionError(PyMongoError):
         return label == "TransientTransactionError"
 
 
+# Define a custom exception to simulate unknown transaction commit result error
+class UnknownTransactionCommitResult(PyMongoError):
+    def has_error_label(self, label: str) -> bool:
+        return label == "UnknownTransactionCommitResult"
+
+
 @pytest.mark.asyncio
 async def test_retry_tx_success() -> None:
     # Define a db operation that succeeds immediately
@@ -70,6 +76,63 @@ async def test_retry_tx_exhaust_retries() -> None:
     # Should be called max_retries times
     assert mock_db_operation.call_count == 3
     assert str(exc.value) == "Transaction failed after maximum retries"
+
+
+@pytest.mark.asyncio
+async def test_retry_commit_success() -> None:
+    # Mock session with a successful commit_transaction call
+    mock_session = AsyncMock()
+    mock_session.commit_transaction = AsyncMock(return_value=None)
+
+    # Call _retry_commit with the mock session
+    await TransactionManager._retry_commit(mock_session)
+
+    # Ensure commit_transaction was called once with no retry
+    mock_session.commit_transaction.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_retry_commit_unknown_commit_result_with_retry() -> None:
+    # Simulate UnknownTransactionCommitResult on the first call, then success
+    mock_session = AsyncMock()
+    mock_session.commit_transaction = AsyncMock(side_effect=[UnknownTransactionCommitResult(), None])
+
+    # Patch sleep for faster testing
+    with patch("src.database.transaction_manager.sleep", new=AsyncMock()):
+        await TransactionManager._retry_commit(mock_session)
+
+    # Called twice due to retry
+    assert mock_session.commit_transaction.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_retry_commit_non_retryable_error() -> None:
+    # Mock session with a non-retryable PyMongoError
+    mock_session = AsyncMock()
+    mock_session.commit_transaction = AsyncMock(side_effect=PyMongoError("Non-retryable error"))
+
+    with pytest.raises(PyMongoError) as exc:
+        await TransactionManager._retry_commit(mock_session)
+
+    # Ensure commit_transaction was called once and not retried
+    mock_session.commit_transaction.assert_awaited_once()
+    assert str(exc.value) == "Non-retryable error"
+
+
+@pytest.mark.asyncio
+async def test_retry_commit_exhaust_retries() -> None:
+    # Simulate UnknownTransactionCommitResult that fails each time
+    mock_session = AsyncMock()
+    mock_session.commit_transaction = AsyncMock(side_effect=UnknownTransactionCommitResult())
+
+    # Patch sleep for faster tests
+    with patch("src.database.transaction_manager.sleep", new=AsyncMock()):
+        with pytest.raises(PyMongoError) as exc:
+            await TransactionManager._retry_commit(mock_session)
+
+    # Ensure commit_transaction was called max_retries times
+    assert mock_session.commit_transaction.call_count == 3
+    assert str(exc.value) == "Commiting transaction failed after maximum retries"
 
 
 @pytest.mark.asyncio

--- a/services/py-api/tests/unit_tests/test_database_layer/test_trancation_manager.py
+++ b/services/py-api/tests/unit_tests/test_database_layer/test_trancation_manager.py
@@ -9,7 +9,7 @@ from src.database.transaction_manager import TransactionManager
 
 
 @pytest.fixture
-def setup_transaction_manager(db_manager_mock: DatabaseManager) -> TransactionManager:
+def tx_manager(db_manager_mock: DatabaseManager) -> TransactionManager:
     return TransactionManager(db_manager_mock)
 
 
@@ -26,168 +26,110 @@ class UnknownTransactionCommitResult(PyMongoError):
 
 
 @pytest.mark.asyncio
-async def test_retry_tx_success() -> None:
-    # Define a db operation that succeeds immediately
+async def test_with_transaction_success(
+    tx_manager: TransactionManager, db_manager_mock: Mock, db_client_session_mock: MagicMock
+) -> None:
+    # Mock a successful db operation
     mock_db_operation = AsyncMock(return_value=Ok("Success"))
+    result = await tx_manager.with_transaction(mock_db_operation)
 
-    result = await TransactionManager._retry_tx(mock_db_operation)
-
-    mock_db_operation.assert_awaited_once()
+    db_manager_mock.client.start_session.assert_called_once()
+    db_client_session_mock.start_transaction.assert_called_once()
+    db_client_session_mock.commit_transaction.assert_awaited_once()
+    db_client_session_mock.abort_transaction.assert_not_called()
+    db_client_session_mock.end_session.assert_awaited_once()
     assert result == Ok("Success")
 
 
 @pytest.mark.asyncio
-async def test_retry_tx_transient_error_with_retry() -> None:
+async def test_with_transaction_transient_error(
+    tx_manager: TransactionManager, db_manager_mock: Mock, db_client_session_mock: MagicMock
+) -> None:
     # Simulate transient error on the first call, then success
     mock_db_operation = AsyncMock(side_effect=[TransientTransactionError(), Ok("Success")])
 
-    # Patch sleep for faster testing
+    # We patch the sleep function for faster testing
     with patch("src.database.transaction_manager.sleep", new=AsyncMock()):
-        result = await TransactionManager._retry_tx(mock_db_operation)
+        result = await tx_manager.with_transaction(mock_db_operation)
 
-    # Called twice due to retry
-    assert mock_db_operation.call_count == 2
-    assert result == Ok("Success")
+        db_manager_mock.client.start_session.assert_called_once()
+        db_client_session_mock.start_transaction.assert_called_once()
+        db_client_session_mock.commit_transaction.assert_awaited_once()
+        db_client_session_mock.abort_transaction.assert_not_called()
+        db_client_session_mock.end_session.assert_awaited_once()
 
-
-@pytest.mark.asyncio
-async def test_retry_tx_non_retryable_error() -> None:
-    # Simulate a non-retryable error
-    mock_db_operation = AsyncMock(side_effect=PyMongoError("Non-retryable error"))
-
-    with pytest.raises(PyMongoError) as exc:
-        await TransactionManager._retry_tx(mock_db_operation)
-
-    # Should only be called once, no retry
-    mock_db_operation.assert_awaited_once()
-    assert str(exc.value) == "Non-retryable error"
+        # On the first call it failed and on the second call it succeeded
+        assert mock_db_operation.call_count == 2
+        assert result == Ok("Success")
 
 
 @pytest.mark.asyncio
-async def test_retry_tx_exhaust_retries() -> None:
+async def test_with_transaction_unknown_commit_result_error(
+    tx_manager: TransactionManager, db_manager_mock: Mock, db_client_session_mock: MagicMock
+) -> None:
+    # Mock a successful db operation
+    mock_db_operation = AsyncMock(return_value=Ok("Success"))
+    # Mock a commit failing first and then succeeding
+    db_client_session_mock.commit_transaction = AsyncMock(
+        side_effect=[UnknownTransactionCommitResult("Test err"), None]
+    )
+
+    # We patch the sleep function for faster testing
+    with patch("src.database.transaction_manager.sleep", new=AsyncMock()):
+        result = await tx_manager.with_transaction(mock_db_operation)
+
+        db_manager_mock.client.start_session.assert_called_once()
+        db_client_session_mock.start_transaction.assert_called_once()
+        db_client_session_mock.abort_transaction.assert_not_called()
+        db_client_session_mock.end_session.assert_awaited_once()
+
+        # On the first call it failed and on the second call it succeeded
+        assert db_client_session_mock.commit_transaction.call_count == 2
+        assert result == Ok("Success")
+
+
+@pytest.mark.asyncio
+async def test_with_transaction_exhaust_retries(
+    tx_manager: TransactionManager, db_manager_mock: Mock, db_client_session_mock: MagicMock
+) -> None:
     # Simulate a transient error that keeps failing
     mock_db_operation = AsyncMock(side_effect=TransientTransactionError())
 
-    # Patch sleep for faster tests
+    # We patch the sleep function for faster testing
     with patch("src.database.transaction_manager.sleep", new=AsyncMock()):
-        with pytest.raises(PyMongoError) as exc:
-            await TransactionManager._retry_tx(mock_db_operation)
+        result = await tx_manager.with_transaction(mock_db_operation)
 
-    # Should be called max_retries times
-    assert mock_db_operation.call_count == 3
-    assert str(exc.value) == "Transaction failed after maximum retries"
+        db_manager_mock.client.start_session.assert_called_once()
+        db_client_session_mock.start_transaction.assert_called_once()
+        db_client_session_mock.commit_transaction.assert_not_called()
+        db_client_session_mock.abort_transaction.assert_awaited_once()
+        db_client_session_mock.end_session.assert_awaited_once()
 
-
-@pytest.mark.asyncio
-async def test_retry_commit_success() -> None:
-    # Mock session with a successful commit_transaction call
-    mock_session = AsyncMock()
-    mock_session.commit_transaction = AsyncMock(return_value=None)
-
-    # Call _retry_commit with the mock session
-    await TransactionManager._retry_commit(mock_session)
-
-    # Ensure commit_transaction was called once with no retry
-    mock_session.commit_transaction.assert_awaited_once()
+        # Should be called max_retries times
+        assert mock_db_operation.call_count == 3
+        assert isinstance(result, Err)
+        assert isinstance(result.err_value, PyMongoError)
 
 
 @pytest.mark.asyncio
-async def test_retry_commit_unknown_commit_result_with_retry() -> None:
-    # Simulate UnknownTransactionCommitResult on the first call, then success
-    mock_session = AsyncMock()
-    mock_session.commit_transaction = AsyncMock(side_effect=[UnknownTransactionCommitResult(), None])
+async def test_with_transaction_unknown_commit_result_exhaust_retries(
+    tx_manager: TransactionManager, db_manager_mock: Mock, db_client_session_mock: MagicMock
+) -> None:
+    # Mock a successful db operation
+    mock_db_operation = AsyncMock(return_value=Ok("Success"))
+    # Simulate a commit error that keeps failing
+    db_client_session_mock.commit_transaction = AsyncMock(side_effect=UnknownTransactionCommitResult("Test err"))
 
-    # Patch sleep for faster testing
+    # We patch the sleep function for faster testing
     with patch("src.database.transaction_manager.sleep", new=AsyncMock()):
-        await TransactionManager._retry_commit(mock_session)
+        result = await tx_manager.with_transaction(mock_db_operation)
 
-    # Called twice due to retry
-    assert mock_session.commit_transaction.call_count == 2
+        db_manager_mock.client.start_session.assert_called_once()
+        db_client_session_mock.start_transaction.assert_called_once()
+        db_client_session_mock.abort_transaction.assert_awaited_once()
+        db_client_session_mock.end_session.assert_awaited_once()
 
-
-@pytest.mark.asyncio
-async def test_retry_commit_non_retryable_error() -> None:
-    # Mock session with a non-retryable PyMongoError
-    mock_session = AsyncMock()
-    mock_session.commit_transaction = AsyncMock(side_effect=PyMongoError("Non-retryable error"))
-
-    with pytest.raises(PyMongoError) as exc:
-        await TransactionManager._retry_commit(mock_session)
-
-    # Ensure commit_transaction was called once and not retried
-    mock_session.commit_transaction.assert_awaited_once()
-    assert str(exc.value) == "Non-retryable error"
-
-
-@pytest.mark.asyncio
-async def test_retry_commit_exhaust_retries() -> None:
-    # Simulate UnknownTransactionCommitResult that fails each time
-    mock_session = AsyncMock()
-    mock_session.commit_transaction = AsyncMock(side_effect=UnknownTransactionCommitResult())
-
-    # Patch sleep for faster tests
-    with patch("src.database.transaction_manager.sleep", new=AsyncMock()):
-        with pytest.raises(PyMongoError) as exc:
-            await TransactionManager._retry_commit(mock_session)
-
-    # Ensure commit_transaction was called max_retries times
-    assert mock_session.commit_transaction.call_count == 3
-    assert str(exc.value) == "Commiting transaction failed after maximum retries"
-
-
-@pytest.mark.asyncio
-async def test_with_transaction_success(setup_transaction_manager: TransactionManager, db_manager_mock: Mock) -> None:
-    tx_manager = setup_transaction_manager
-
-    # Create a mock session to be returned by the start_session method
-    mock_session = MagicMock()
-    db_manager_mock.client.start_session.return_value = mock_session
-
-    # `start_transaction` is synchronous and returns a context manager _MotorTransactionContext, that's why we need
-    # MagicMock
-    mock_session.start_transaction = MagicMock()
-    mock_session.commit_transaction = AsyncMock()  # `commit_transaction` is async
-    mock_session.abort_transaction = AsyncMock()  # `abort_transaction` is async
-    mock_session.end_session = AsyncMock()  # `end_session` is async
-
-    # Mock callback function that represents the transaction
-    async def mock_callback(session: MagicMock) -> Ok:
-        return Ok("Success")
-
-    result = await tx_manager.with_transaction(mock_callback)
-
-    db_manager_mock.client.start_session.assert_called_once()
-    mock_session.start_transaction.assert_called_once()
-    mock_session.commit_transaction.assert_awaited_once()
-    mock_session.abort_transaction.assert_not_called()
-    mock_session.end_session.assert_awaited_once()
-    assert result == Ok("Success")
-
-
-@pytest.mark.asyncio
-async def test_with_transaction_failure(setup_transaction_manager: TransactionManager, db_manager_mock: Mock) -> None:
-    tx_manager = setup_transaction_manager
-
-    # Create a mock session to be returned by the start_session method
-    mock_session = MagicMock()
-    db_manager_mock.client.start_session.return_value = mock_session
-
-    # `start_transaction` is synchronous and returns a context manager _MotorTransactionContext, that's why we need
-    # MagicMock
-    mock_session.start_transaction = MagicMock()
-    mock_session.commit_transaction = AsyncMock()  # `commit_transaction` is async
-    mock_session.abort_transaction = AsyncMock()  # `abort_transaction` is async
-    mock_session.end_session = AsyncMock()  # `end_session` is async
-
-    # Define a callback function that raises an exception
-    async def mock_callback(session: AsyncMock) -> Err:
-        return Err(ValueError("Simulated failure"))
-
-    result = await tx_manager.with_transaction(mock_callback)
-
-    db_manager_mock.client.start_session.assert_called_once()
-    mock_session.start_transaction.assert_called_once()
-    mock_session.abort_transaction.assert_awaited_once()
-    mock_session.commit_transaction.assert_not_called()
-    mock_session.end_session.assert_awaited_once()
-    assert isinstance(result, Err)
+        # Should be called max_retries times
+        assert db_client_session_mock.commit_transaction.call_count == 3
+        assert isinstance(result, Err)
+        assert isinstance(result.err_value, PyMongoError)


### PR DESCRIPTION
#747 Add retrying of UnknownTransactionCommitResult Error

## Added the retry logic to commit_transaction
It is done in the same fashion as the _retry_tx is done using exponential backoff for retrying. However, it does not return a result.OK object since commit_transaction does not return anything


resolves #747  

## How to verify:

- [ ] Create a new participant through the creation endpoint

