### PR TITLE
#762 Write the exception traceback in the logfile

### DIFF
--- a/services/py-api/src/database/transaction_manager.py
+++ b/services/py-api/src/database/transaction_manager.py
@@ -141,7 +141,7 @@ class TransactionManager:
             return result
 
         except Exception as e:
-            LOG.exception("Aborting transaction due to err {}".format(e))
+            LOG.warning("Aborting transaction due to err {}".format(e))
             await session.abort_transaction()
             return Err(e)
 

--- a/services/py-api/src/database/transaction_manager.py
+++ b/services/py-api/src/database/transaction_manager.py
@@ -141,7 +141,7 @@ class TransactionManager:
             return result
 
         except Exception as e:
-            LOG.warning("Aborting transaction due to err {}".format(e))
+            LOG.exception("Aborting transaction due to err {}".format(e))
             await session.abort_transaction()
             return Err(e)
 

--- a/services/py-api/src/server/config/server_config.py
+++ b/services/py-api/src/server/config/server_config.py
@@ -11,7 +11,7 @@ from src.utils import SingletonMeta
 
 # This should be called first because the env variables should be loaded into the process before we start using them
 # across our codebase
-load_dotenv()
+load_dotenv(override=True)
 
 # We also configure the logger here. This should be done before calling LOG = get_logger(), which we use in almost
 # every file, in order for the logger to function properly. Otherwise, it uses the default logging config.

--- a/services/py-api/src/server/logger/logger_factory.py
+++ b/services/py-api/src/server/logger/logger_factory.py
@@ -7,7 +7,6 @@ from structlog.contextvars import merge_contextvars
 from structlog.dev import ConsoleRenderer
 from structlog.processors import (
     TimeStamper,
-    ExceptionPrettyPrinter,
     StackInfoRenderer,
     CallsiteParameterAdder,
     CallsiteParameter,
@@ -83,9 +82,8 @@ def configure_app_logger(env: str) -> None:
             add_log_level,
             merge_contextvars,
             TimeStamper(fmt="%Y-%m-%d %H:%M:%S"),
-            ExceptionPrettyPrinter(),
-            StackInfoRenderer(),
             format_exc_info,
+            StackInfoRenderer(),
             PositionalArgumentsFormatter(),
             CallsiteParameterAdder(
                 {


### PR DESCRIPTION
#762 Writes the exception traceback in the logfile for PROD and DEV environments

### What was the issue
We were using conflicting processors for structlog, this caused the issue of the exception not being printed in the file. Moreover, I noticed a weird behaviour with the way the .env file is interpreted by load_dotenv in my machine. It seems like it was using some sort of caching system to make the reading of the env variables faster and it was not listening to new changes I was making in the .env. I literally deleted the .env file and the app was still running. To solve this issue I read a little more about load_dotenv works, which you can check on the picture below: 
<img width="852" alt="Screenshot 2024-11-09 at 1 50 13 PM" src="https://github.com/user-attachments/assets/09ff8246-1f8e-4261-a064-c904aedba602">
Apparently, if you do not specify a value for override it defaults to False, which means that the function will first look for the value of that variable in the environment (not sure of what what they mean by environment here) and only after this in the .env file. For this reason, I change the override=True, solving the issue I was facing. 

resolves #762 

## How to verify (Please test it):

- [ ] Change part of the code in our create participant method to trigger and exception

- [ ] Switch the ENV variable to DEV or PROD

- [ ] Run the application

- [ ] Send a request to the application so that it raises an exception

- [ ] Check the logs in shared/server.log

- [ ] if "excpetion" is part of the JSON object

