### PR TITLE
#745 Encode And Decode Methods for JWT 

### DIFF
--- a/services/py-api/src/utils.py
+++ b/services/py-api/src/utils.py
@@ -1,7 +1,9 @@
+from os import environ
 from threading import Lock
-from typing import Any, Dict
-
+from typing import Any, Dict, TypedDict
+from jwt import DecodeError, ExpiredSignatureError, InvalidSignatureError, decode, encode
 import httpx
+import jwt
 from structlog.stdlib import get_logger
 
 LOG = get_logger()
@@ -43,3 +45,37 @@ class AsyncClient(metaclass=SingletonMeta):
             raise RuntimeError("The AsyncClient has not been initialized!")
 
         await self._async_client.aclose()
+
+class JwtUtility:
+    class UserData(TypedDict):
+        id: int
+        name: str
+        email: str
+        is_admin: bool
+        email_verified: bool
+        team_id: int
+        created_at: str
+        updated_at: str
+         
+
+    @staticmethod
+    def encode(data: UserData) -> str:
+            return encode(data,key=environ["SECRET_KEY"])
+    
+    @staticmethod
+    def decode(token: str) -> Dict[str, Any]:
+     try:
+        decoded_payload=jwt.decode(token, SECRET_KEY, algorithms=["HS256"])
+        return decoded_payload
+     except ExpiredSignatureError:
+            print("The token has expired.")
+            return {"error": "TokenExpired"}
+     except InvalidSignatureError:
+            print("The token has an invalid signature.")
+            return {"error": "InvalidSignature"}
+     except DecodeError:
+            print("There was an error decoding the token.")
+            return {"error": "DecodeError"}
+    
+
+print(JwtUtility.encode({"str":"fdsafsad"}))


### PR DESCRIPTION
#745 Added encoding And decoding Methods for JWT 

## Added encode and decode functions:
Encode and decode functions with a check for decode errors. A class TypedDict including the participant data.


resolves #745

## How to verify:

- [ ] Start the Techno Symphony: Launch the API and let the servers hum with anticipation.

- [ ] Open your browser or API client and head to /v2/webhooks.

- [ ] Trigger the endpoint with a confident click or keystroke.

- [ ] Read the server's message - success (200 OK) or a mysterious error (404, 500)?

- [ ] Dance with joy for success, or wear the debug wizard hat to troubleshoot any hiccups.

- [ ] With these steps, you'll traverse the enchanting realm of webhooks and endpoints, witnessing the dance of data and code. 🚀🎶💻

