### PR TITLE
Add retry to single db operations

### DIFF
--- a/services/py-api/src/database/db_manager.py
+++ b/services/py-api/src/database/db_manager.py
@@ -120,7 +120,6 @@ class DatabaseManager(metaclass=SingletonMeta):
                 # re-raise it in order to be caught on an upper level
                 raise exc
 
-        # Raised
         raise PyMongoError("Database operation failed after maximum retries")
 
 

--- a/services/py-api/src/database/db_manager.py
+++ b/services/py-api/src/database/db_manager.py
@@ -106,8 +106,7 @@ class DatabaseManager(metaclass=SingletonMeta):
 
                 # Retryable read error
                 # https://github.com/mongodb/mongo-python-driver/blob/2d21035396f63437176965cc8f157505189f2f08/pymongo/asynchronous/mongo_client.py#L2590-L2603
-                if isinstance(exc, (ConnectionFailure, OperationFailure)) and is_read_operation:
-                    # ConnectionFailures do not supply a code property that's why None is passed as a third argument
+                if isinstance(exc, OperationFailure) and is_read_operation:
                     # If the read error is not retryable re-raise it
                     if getattr(exc, "code", None) not in helpers_shared._RETRYABLE_ERROR_CODES:
                         raise exc

--- a/services/py-api/src/database/repository/participants_repository.py
+++ b/services/py-api/src/database/repository/participants_repository.py
@@ -99,6 +99,10 @@ class ParticipantsRepository(CRUDRepository):
 
     async def get_verified_random_participants_count(self) -> int:
         """Returns the count of verified participants who are not assigned to any team."""
+
         # Ignoring mypy type due to mypy err: 'Returning Any from function declared to return "int"  [no-any-return]'
         # which is not true
-        return await self._collection.count_documents({"email_verified": True, "team_id": None})  # type: ignore
+        async def db_operation() -> None:
+            await self._collection.count_documents({"email_verified": True, "team_id": None})
+
+        return self._db_manager.retry_db_operation(db_operation, is_read_operation=True)  # type: ignore

--- a/services/py-api/src/database/repository/participants_repository.py
+++ b/services/py-api/src/database/repository/participants_repository.py
@@ -102,7 +102,7 @@ class ParticipantsRepository(CRUDRepository):
 
         # Ignoring mypy type due to mypy err: 'Returning Any from function declared to return "int"  [no-any-return]'
         # which is not true
-        async def db_operation() -> None:
-            await self._collection.count_documents({"email_verified": True, "team_id": None})
+        async def db_operation() -> int:
+            return await self._collection.count_documents({"email_verified": True, "team_id": None})  # type: ignore
 
-        return self._db_manager.retry_db_operation(db_operation, is_read_operation=True)  # type: ignore
+        return await self._db_manager.retry_db_operation(db_operation, is_read_operation=True)

--- a/services/py-api/src/database/repository/participants_repository.py
+++ b/services/py-api/src/database/repository/participants_repository.py
@@ -65,12 +65,13 @@ class ParticipantsRepository(CRUDRepository):
         session: Optional[AsyncIOMotorClientSession] = None,
         **kwargs: Dict[str, Any]
     ) -> Result[Participant, DuplicateEmailError | Exception]:
+        """Creating a Participant object in the database. If the `team_id` is passed as a kwarg the participant will be
+        inserted as part of the given team"""
 
         participant = Participant(
             name=input_data.name,
             email=input_data.email,
             is_admin=input_data.is_admin,
-            # If the team_id is passed as a kwarg the participant will be inserted in the given team
             team_id=kwargs.get("team_id"),
         )
 

--- a/services/py-api/src/database/repository/participants_repository.py
+++ b/services/py-api/src/database/repository/participants_repository.py
@@ -84,8 +84,8 @@ class ParticipantsRepository(CRUDRepository):
             # mechanism
             if session:
                 await db_operation()
-
-            await self._db_manager.retry_db_operation(db_operation, is_read_operation=False)
+            else:
+                await self._db_manager.retry_db_operation(db_operation, is_read_operation=False)
 
             return Ok(participant)
 

--- a/services/py-api/src/database/repository/participants_repository.py
+++ b/services/py-api/src/database/repository/participants_repository.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, Dict
+from typing import Optional, Any, Dict, Mapping
 
 from bson import ObjectId
 from motor.motor_asyncio import AsyncIOMotorClientSession
@@ -39,15 +39,28 @@ class ParticipantsRepository(CRUDRepository):
         """
         Deletes the participant which corresponds to the provided object_id
         """
-        try:
 
-            LOG.debug("Deleting participant...", participant_obj_id=obj_id)
-
+        async def db_operation() -> Mapping[str, Any]:
             # According to mongodb docs result is of type _DocumentType:
             # https://pymongo.readthedocs.io/en/4.8.0/api/pymongo/collection.html#pymongo.collection.Collection.find_one_and_delete
             # _id is projected because ObjectID is not serializable.
             # We use the Participant data class to represent the deleted participant.
-            result = await self._collection.find_one_and_delete(filter={"_id": ObjectId(obj_id)}, projection={"_id": 0})
+            delete_result = await self._collection.find_one_and_delete(
+                filter={"_id": ObjectId(obj_id)}, projection={"_id": 0}
+            )
+            # Ignoring mypy type due to mypy err: 'Returning Any from function declared to return "int"  [no-any-return]'
+            # which is not true
+            return delete_result  # type: ignore
+
+        try:
+            LOG.debug("Deleting participant...", participant_obj_id=obj_id)
+
+            # The `TransactionManager.with_transaction` method provides the session and has a built-in retry
+            # mechanism
+            if session:
+                result = await db_operation()
+            else:
+                result = await self._db_manager.retry_db_operation(db_operation, is_read_operation=False)
 
             # The result is None when the participant with the specified ObjectId is not found
             if result:

--- a/services/py-api/src/database/repository/teams_repository.py
+++ b/services/py-api/src/database/repository/teams_repository.py
@@ -108,7 +108,7 @@ class TeamsRepository(CRUDRepository):
 
         # Ignoring mypy type due to mypy err: 'Returning Any from function declared to return "int"  [no-any-return]'
         # which is not true
-        async def db_operation() -> None:
-            await self._collection.count_documents({"is_verified": True})
+        async def db_operation() -> int:
+            return await self._collection.count_documents({"is_verified": True})  # type: ignore
 
-        return self._db_manager.retry_db_operation(db_operation, is_read_operation=True)  # type: ignore
+        return await self._db_manager.retry_db_operation(db_operation, is_read_operation=True)

--- a/services/py-api/src/database/repository/teams_repository.py
+++ b/services/py-api/src/database/repository/teams_repository.py
@@ -46,8 +46,8 @@ class TeamsRepository(CRUDRepository):
             # mechanism
             if session:
                 await db_operation()
-
-            await self._db_manager.retry_db_operation(db_operation, is_read_operation=False)
+            else:
+                await self._db_manager.retry_db_operation(db_operation, is_read_operation=False)
 
             return Ok(team)
 

--- a/services/py-api/src/database/transaction_manager.py
+++ b/services/py-api/src/database/transaction_manager.py
@@ -54,7 +54,7 @@ class TransactionManager:
             PyMongoError
         """
         max_retries = 3
-        delay = 1  # initial delay in seconds
+        delay = 0.2  # initial delay in seconds (200 milliseconds)
 
         # range is exclusive that's why we do max_retries + 1
         for retry in range(1, max_retries + 1):
@@ -80,7 +80,7 @@ class TransactionManager:
         https://www.mongodb.com/docs/manual/core/transactions-in-applications/#example-1
         """
         max_retries = 3
-        delay = 1  # initial delay in seconds
+        delay = 0.2  # initial delay in seconds (200 milliseconds)
 
         # range is exclusive that's why we do max_retries + 1
         for retry in range(1, max_retries + 1):

--- a/services/py-api/src/database/transaction_manager.py
+++ b/services/py-api/src/database/transaction_manager.py
@@ -62,12 +62,13 @@ class TransactionManager:
                 return await func(*args, **kwargs)
             except PyMongoError as exc:
                 if exc.has_error_label("TransientTransactionError"):
-                    LOG.debug("Retrying transaction retry {}".format(retry))
+                    LOG.debug("Retrying transaction. Retry {}".format(retry))
                     await sleep(delay)
                     delay *= 2  # exponential backoff
                     continue
 
-                # If the exception it's a non-retryable error re-raise it in order to be caught on an upper level
+                # If the exception is a non-retryable error or is a transactional error which didn't manage to
+                # propagate, re-raise it in order to be caught on an upper level
                 raise exc
 
         raise PyMongoError("Transaction failed after maximum retries")

--- a/services/py-api/tests/unit_tests/conftest.py
+++ b/services/py-api/tests/unit_tests/conftest.py
@@ -36,6 +36,7 @@ def db_manager_mock(db_client_session_mock: Mock) -> Mock:
     # We use AsyncMock, as the original AsyncIOMotorClient class has async methods
     db_manager.client = AsyncMock()
     db_manager.get_collection.return_value = AsyncMock()
+    db_manager.retry_db_operation = AsyncMock()
     db_manager.client.start_session.return_value = db_client_session_mock
     db_manager.async_ping_db = AsyncMock(return_value=None)
 
@@ -122,9 +123,11 @@ def participant_registration_service_mock() -> Mock:
 def mock_input_data() -> ParticipantRequestBody:
     return ParticipantRequestBody(name="Test User", email="test@example.com", team_name="Test Team", is_admin=True)
 
+
 @pytest.fixture
 def mock_input_data_random() -> ParticipantRequestBody:
     return ParticipantRequestBody(name="Test User", email="test@example.com", team_id=None, is_admin=False)
+
 
 @pytest.fixture
 def response_mock() -> MagicMock:

--- a/services/py-api/tests/unit_tests/test_database_layer/test_db_manager.py
+++ b/services/py-api/tests/unit_tests/test_database_layer/test_db_manager.py
@@ -1,8 +1,8 @@
 from unittest.mock import patch, AsyncMock
 
 import pytest
-from pymongo.errors import ConnectionFailure
-from result import Err
+from pymongo.errors import ConnectionFailure, PyMongoError, OperationFailure
+from result import Err, Ok
 
 from src.database.db_manager import DatabaseManager
 from src.utils import SingletonMeta
@@ -24,6 +24,12 @@ def db_manager() -> DatabaseManager:
         # https://stackoverflow.com/questions/42565304/is-it-possible-to-ping-mongodb-from-pymongo
         with patch("src.database.db_manager.environ", {"DATABASE_URL": "mongodb+srv://test_url"}):
             return DatabaseManager()
+
+
+# Define a custom exception to simulate transient transaction error
+class RetryableWriteError(PyMongoError):
+    def has_error_label(self, label: str) -> bool:
+        return label == "RetryableWriteError"
 
 
 @pytest.fixture
@@ -66,3 +72,71 @@ async def test_close_all_connections_success(db_manager: DatabaseManager) -> Non
 async def test_close_all_connections_err(db_manager_none_client: DatabaseManager) -> None:
     result = db_manager_none_client.close_all_connections()
     isinstance(result, Err)
+
+
+@pytest.mark.asyncio
+async def test_retry_read_db_operation_success(db_manager: DatabaseManager) -> None:
+    # Mock a successful db operation
+    mock_db_operation = AsyncMock(return_value=Ok("Success"))
+    result = await db_manager.retry_db_operation(mock_db_operation, is_read_operation=True)
+
+    assert mock_db_operation.call_count == 1
+    assert result == Ok("Success")
+
+
+@pytest.mark.asyncio
+async def test_retry_read_db_operation_retryable_error(db_manager: DatabaseManager) -> None:
+    # Mock a successful db operation
+    mock_db_operation = AsyncMock(side_effect=[OperationFailure("Test err", 7), Ok("Success")])
+
+    # We patch the sleep function for faster testing
+    with patch("src.database.db_manager.sleep", new=AsyncMock()):
+        result = await db_manager.retry_db_operation(mock_db_operation, is_read_operation=True)
+
+        # On the first call it failed and on the second call it succeeded
+        assert mock_db_operation.call_count == 2
+        assert result == Ok("Success")
+
+
+@pytest.mark.asyncio
+async def test_retry_read_db_operation_retryable_error_exhaust_retries(db_manager: DatabaseManager) -> None:
+    # Simulate a retryable read err that keeps failing
+    mock_db_operation = AsyncMock(side_effect=OperationFailure("Test err", 7))
+    with pytest.raises(PyMongoError):
+        await db_manager.retry_db_operation(mock_db_operation, is_read_operation=True)
+
+    assert mock_db_operation.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_retry_write_db_operation_success(db_manager: DatabaseManager) -> None:
+    # Mock a successful db operation
+    mock_db_operation = AsyncMock(return_value=Ok("Success"))
+    result = await db_manager.retry_db_operation(mock_db_operation, is_read_operation=False)
+
+    assert mock_db_operation.call_count == 1
+    assert result == Ok("Success")
+
+
+@pytest.mark.asyncio
+async def test_write_read_db_operation_retryable_error(db_manager: DatabaseManager) -> None:
+    # Mock a successful db operation
+    mock_db_operation = AsyncMock(side_effect=[RetryableWriteError(), Ok("Success")])
+
+    # We patch the sleep function for faster testing
+    with patch("src.database.db_manager.sleep", new=AsyncMock()):
+        result = await db_manager.retry_db_operation(mock_db_operation, is_read_operation=False)
+
+        # On the first call it failed and on the second call it succeeded
+        assert mock_db_operation.call_count == 2
+        assert result == Ok("Success")
+
+
+@pytest.mark.asyncio
+async def test_retry_write_db_operation_retryable_error_exhaust_retries(db_manager: DatabaseManager) -> None:
+    # Simulate a retryable read err that keeps failing
+    mock_db_operation = AsyncMock(side_effect=RetryableWriteError())
+    with pytest.raises(PyMongoError):
+        await db_manager.retry_db_operation(mock_db_operation, is_read_operation=False)
+
+    assert mock_db_operation.call_count == 2

--- a/services/py-api/tests/unit_tests/test_database_layer/test_db_manager.py
+++ b/services/py-api/tests/unit_tests/test_database_layer/test_db_manager.py
@@ -26,7 +26,7 @@ def db_manager() -> DatabaseManager:
             return DatabaseManager()
 
 
-# Define a custom exception to simulate transient transaction error
+# Define a custom exception to simulate retryable write error
 class RetryableWriteError(PyMongoError):
     def has_error_label(self, label: str) -> bool:
         return label == "RetryableWriteError"

--- a/services/py-api/tests/unit_tests/test_database_layer/test_participant_repository.py
+++ b/services/py-api/tests/unit_tests/test_database_layer/test_participant_repository.py
@@ -44,9 +44,7 @@ async def test_create_participant_duplicate_email_error(
     db_manager_mock: Mock, mock_input_data: ParticipantRequestBody, repo: ParticipantsRepository
 ) -> None:
     # Simulate a DuplicateKeyError raised by insert_one to represent a duplicate email
-    db_manager_mock.get_collection.return_value.insert_one = AsyncMock(
-        side_effect=DuplicateKeyError("Duplicate email error")
-    )
+    db_manager_mock.retry_db_operation = AsyncMock(side_effect=DuplicateKeyError("Duplicate email error"))
 
     result = await repo.create(mock_input_data)
 
@@ -61,7 +59,7 @@ async def test_create_participant_general_exception(
     db_manager_mock: Mock, mock_input_data: ParticipantRequestBody, repo: ParticipantsRepository
 ) -> None:
     # Simulate a general exception raised by insert_one
-    db_manager_mock.get_collection.return_value.insert_one = AsyncMock(side_effect=Exception("Test error"))
+    db_manager_mock.retry_db_operation = AsyncMock(side_effect=Exception("Test error"))
 
     result = await repo.create(mock_input_data)
 

--- a/services/py-api/tests/unit_tests/test_database_layer/test_team_repository.py
+++ b/services/py-api/tests/unit_tests/test_database_layer/test_team_repository.py
@@ -41,9 +41,7 @@ async def test_create_team_duplicate_name_error(
     db_manager_mock: Mock, mock_input_data: ParticipantRequestBody, repo: TeamsRepository
 ) -> None:
     # Simulate a DuplicateKeyError raised by insert_one to represent a duplicate team name
-    db_manager_mock.get_collection.return_value.insert_one = AsyncMock(
-        side_effect=DuplicateKeyError("Duplicate team name error")
-    )
+    db_manager_mock.retry_db_operation = AsyncMock(side_effect=DuplicateKeyError("Duplicate team name error"))
 
     result = await repo.create(mock_input_data)
 
@@ -58,7 +56,7 @@ async def test_create_team_general_exception(
     db_manager_mock: Mock, mock_input_data: ParticipantRequestBody, repo: TeamsRepository
 ) -> None:
     # Simulate a general exception raised by insert_one
-    db_manager_mock.get_collection.return_value.insert_one = AsyncMock(side_effect=Exception("Test error"))
+    db_manager_mock.retry_db_operation = AsyncMock(side_effect=Exception("Test error"))
 
     result = await repo.create(mock_input_data)
 


### PR DESCRIPTION
In the future, we may need to use single db operations. As Mongo Atlas is a managed db and is deployed in AWS Frankfurt (eu-central-1), it is also clustered. Having a retry mechanism when working with remote systems is a good practice to increase reliability.