### PR TITLE
#808 verify random participant flow

### DIFF
--- a/services/py-api/src/database/model/participant_model.py
+++ b/services/py-api/src/database/model/participant_model.py
@@ -1,4 +1,6 @@
+from abc import ABC
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Dict, Any, Optional, Union
 
 from pydantic import BaseModel, EmailStr
@@ -41,7 +43,11 @@ class Participant(BaseDbModel):
         }
 
 
-class UpdatedParticipant(BaseModel):
+class UpdateParams(BaseModel, ABC):
+    updated_at: datetime = datetime.now()
+
+
+class UpdatedParticipant(UpdateParams):
     """This model makes each field of the Participant optional, so that you can
     only set values to the fields that you want to modify and pass to the
     MongoDB find_one_and_update() method.

--- a/services/py-api/src/database/model/participant_model.py
+++ b/services/py-api/src/database/model/participant_model.py
@@ -45,6 +45,7 @@ class UpdatedParticipant(BaseModel):
     """This model makes each field of the Participant optional, so that you can
     only set values to the fields that you want to modify and pass to the
     MongoDB find_one_and_update() method.
+    Build to be used for updating the Participant document in the database.
     """
 
     name: Union[str, None] = None

--- a/services/py-api/src/database/model/participant_model.py
+++ b/services/py-api/src/database/model/participant_model.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, Union
 
+from pydantic import BaseModel, EmailStr
 from src.database.model.base_model import BaseDbModel, SerializableObjectId
 
 
@@ -38,3 +39,29 @@ class Participant(BaseDbModel):
             "created_at": self.created_at.strftime("%Y-%m-%d %H:%M:%S"),
             "updated_at": self.updated_at.strftime("%Y-%m-%d %H:%M:%S"),
         }
+
+
+class UpdatedParticipant(BaseModel):
+    """This model makes each field of the Participant optional, so that you can
+    only set values to the fields that you want to modify and pass to the
+    MongoDB find_one_and_update() method.
+    """
+
+    name: Union[str, None] = None
+    email: Union[EmailStr, None] = None
+    email_verified: Union[bool, None] = None
+    is_admin: Union[bool, None] = None
+    team_id: Union[str, None] = None
+
+    # Override the base class methods to exclude none by default, since we don't want the None values
+    # to be present in the model dumps.
+
+    # The base super().model_dump_json() returns a dict[str, Any], however mypy marks it as if it returns `Any`,
+    # for this reason we are ingoring it.
+    def model_dump(self, *, exclude_none: bool = True, **kwargs: dict[str, Any]) -> dict[str, Any]:
+        return super().model_dump(exclude_none=exclude_none, **kwargs)  # type: ignore
+
+    # The base super().model_dump_json() returns a str, however mypy marks it as if it returns `Any`,
+    # for this reason we are ingoring it.
+    def model_dump_json(self, *, exclude_none: bool = True, **kwargs: dict[str, Any]) -> str:
+        return super().model_dump_json(exclude_none=exclude_none, **kwargs)  # type: ignore

--- a/services/py-api/src/database/repository/teams_repository.py
+++ b/services/py-api/src/database/repository/teams_repository.py
@@ -42,8 +42,24 @@ class TeamsRepository(CRUDRepository[Team]):
             LOG.exception("Team insertion failed due to err {}".format(e))
             return Err(e)
 
-    async def fetch_by_id(self, obj_id: str) -> Result[Team, Exception]:
-        raise NotImplementedError()
+    async def fetch_by_id(self, obj_id: str) -> Result[Team, TeamNotFoundError | Exception]:
+        """
+        Fetches a team by ObjectId
+        """
+        try:
+            LOG.debug("Fetching team by ObjectId...", obj_id=obj_id)
+
+            # Query the database for the team with the given ObjectId
+            team = await self._collection.find_one(filter={"_id": ObjectId(obj_id)}, projection={"_id": 0})
+
+            if team is None:  # If no team is found, return an Err
+                return Err(TeamNotFoundError())
+
+            return Ok(Team(id=obj_id, **team))
+
+        except Exception as e:
+            LOG.exception(f"Failed to fetch team by ObjectId {obj_id} due to err {e}")
+            return Err(e)
 
     async def fetch_all(self) -> Result[List[Team], Exception]:
         raise NotImplementedError()

--- a/services/py-api/src/database/repository/teams_repository.py
+++ b/services/py-api/src/database/repository/teams_repository.py
@@ -17,6 +17,7 @@ LOG = get_logger()
 
 
 class TeamsRepository(CRUDRepository[Team]):
+
     MAX_NUMBER_OF_TEAM_MEMBERS: Final[int] = 6
     MAX_NUMBER_OF_VERIFIED_TEAMS_IN_HACKATHON: Final[int] = 12
 

--- a/services/py-api/src/server/exception.py
+++ b/services/py-api/src/server/exception.py
@@ -68,7 +68,7 @@ class TeamNameMissmatchError(CustomError):
     decoded JWT token, when a participant is registering via an invitation link.
     """
 
-    message = "team_name passed in the request body is different from the team_name in the" "decoded JWT token"
+    message = "team_name passed in the request body is different from the team_name in the decoded JWT token"
     status_code = status.HTTP_400_BAD_REQUEST
 
 

--- a/services/py-api/src/server/handlers/verification_handlers.py
+++ b/services/py-api/src/server/handlers/verification_handlers.py
@@ -4,7 +4,7 @@ from src.service.participants_verification_service import ParticipantVerificatio
 from starlette import status
 from src.utils import JwtUtility
 from src.server.schemas.response_schemas.schemas import ErrResponse, ParticipantVerifiedResponse, Response
-from src.server.schemas.jwt_schemas.schemas import JwtParticipantVerification
+from src.server.schemas.jwt_schemas.schemas import JwtParticipantVerificationData
 
 
 class VerificationHandlers(BaseHandler):
@@ -15,7 +15,7 @@ class VerificationHandlers(BaseHandler):
     async def verify_participant(self, jwt_token: str) -> Response:
         # We decode the token here so that we can determine the case of verfication that we
         # are dealing with: `admin verification` or `random participant verification`.
-        result = JwtUtility.decode_data(token=jwt_token, schema=JwtParticipantVerification)
+        result = JwtUtility.decode_data(token=jwt_token, schema=JwtParticipantVerificationData)
 
         if is_err(result):
             return self.handle_error(result.err_value)

--- a/services/py-api/src/server/handlers/verification_handlers.py
+++ b/services/py-api/src/server/handlers/verification_handlers.py
@@ -4,7 +4,7 @@ from src.service.participants_verification_service import ParticipantVerificatio
 from starlette import status
 from src.utils import JwtUtility
 from src.server.schemas.response_schemas.schemas import ErrResponse, ParticipantVerifiedResponse, Response
-from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserData
+from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserVerification
 
 
 class VerificationHandlers(BaseHandler):
@@ -15,7 +15,7 @@ class VerificationHandlers(BaseHandler):
     async def verify_participant(self, jwt_token: str) -> Response:
         # We decode the token here so that we can determine the case of verfication that we
         # are dealing with: `admin verification` or `random participant verification`.
-        result = JwtUtility.decode_data(token=jwt_token, schema=JwtUserData)
+        result = JwtUtility.decode_data(token=jwt_token, schema=JwtUserVerification)
 
         if is_err(result):
             return self.handle_error(result.err_value)

--- a/services/py-api/src/server/handlers/verification_handlers.py
+++ b/services/py-api/src/server/handlers/verification_handlers.py
@@ -4,7 +4,7 @@ from src.service.participants_verification_service import ParticipantVerificatio
 from starlette import status
 from src.utils import JwtUtility
 from src.server.schemas.response_schemas.schemas import ErrResponse, ParticipantVerifiedResponse, Response
-from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserVerification
+from src.server.schemas.jwt_schemas.schemas import JwtParticipantVerification
 
 
 class VerificationHandlers(BaseHandler):
@@ -15,7 +15,7 @@ class VerificationHandlers(BaseHandler):
     async def verify_participant(self, jwt_token: str) -> Response:
         # We decode the token here so that we can determine the case of verfication that we
         # are dealing with: `admin verification` or `random participant verification`.
-        result = JwtUtility.decode_data(token=jwt_token, schema=JwtUserVerification)
+        result = JwtUtility.decode_data(token=jwt_token, schema=JwtParticipantVerification)
 
         if is_err(result):
             return self.handle_error(result.err_value)

--- a/services/py-api/src/server/handlers/verification_handlers.py
+++ b/services/py-api/src/server/handlers/verification_handlers.py
@@ -1,0 +1,37 @@
+from result import is_err
+from src.server.handlers.base_handler import BaseHandler
+from src.service.participants_verification_service import ParticipantVerificationService
+from starlette import status
+from src.utils import JwtUtility
+from src.server.schemas.response_schemas.schemas import ErrResponse, ParticipantVerifiedResponse, Response
+from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserData
+
+
+class VerificationHandlers(BaseHandler):
+
+    def __init__(self, service: ParticipantVerificationService) -> None:
+        self._service = service
+
+    async def verify_participant(self, jwt_token: str) -> Response:
+        # We decode the token here so that we can determine the case of verfication that we
+        # are dealing with: `admin verification` or `random participant verification`.
+        result = JwtUtility.decode_data(token=jwt_token, schema=JwtUserData)
+
+        if is_err(result):
+            return self.handle_error(result.err_value)
+
+        jwt_payload = result.ok_value
+
+        if jwt_payload["is_admin"]:
+            return Response(response_model=ErrResponse("This feature is not yet implemented!"), status_code=501)
+
+        else:
+            result = await self._service.verify_random_participant(jwt_data=jwt_payload)
+
+        if is_err(result):
+            return self.handle_error(result.err_value)
+
+        return Response(
+            response_model=ParticipantVerifiedResponse(participant=result.ok_value[0], team=result.ok_value[1]),
+            status_code=status.HTTP_200_OK,
+        )

--- a/services/py-api/src/server/routes/routes.py
+++ b/services/py-api/src/server/routes/routes.py
@@ -5,10 +5,11 @@ from fastapi import APIRouter, FastAPI
 from src.server.routes.participants_routes import participants_router
 from src.server.routes.utility_routes import utility_router
 from src.server.routes.teams_routes import teams_router
+from src.server.routes.verification_routes import verification_router
 
 
 class Routes:
-    _routers: List[APIRouter] = [utility_router, participants_router, teams_router]
+    _routers: List[APIRouter] = [utility_router, participants_router, teams_router, verification_router]
     """For every part of our system we create a separate router. In order for a router to be visible we should add it
     to the list"""
 

--- a/services/py-api/src/server/routes/verification_routes.py
+++ b/services/py-api/src/server/routes/verification_routes.py
@@ -1,0 +1,26 @@
+from fastapi import APIRouter, Depends
+from src.server.handlers.verification_handlers import VerificationHandlers
+from src.server.schemas.response_schemas.schemas import ErrResponse, ParticipantVerifiedResponse, Response
+from src.service.participants_verification_service import ParticipantVerificationService
+from src.service.hackathon_service import HackathonService
+from src.server.routes.dependency_factory import _h_service
+
+
+verification_router = APIRouter(prefix="/hackathon/participants/verify")
+
+
+def _p_verify_service(h_service: HackathonService = Depends(_h_service)) -> ParticipantVerificationService:
+    return ParticipantVerificationService(h_service)
+
+
+def _handler(p_verify_service: ParticipantVerificationService = Depends(_p_verify_service)) -> VerificationHandlers:
+    return VerificationHandlers(p_verify_service)
+
+
+@verification_router.patch(
+    "",
+    status_code=200,
+    responses={200: {"model": ParticipantVerifiedResponse}, 404: {"model": ErrResponse}},
+)
+async def verify_participant(jwt_token: str, _handler: VerificationHandlers = Depends(_handler)) -> Response:
+    return await _handler.verify_participant(jwt_token=jwt_token)

--- a/services/py-api/src/server/schemas/jwt_schemas/jwt_user_data_schema.py
+++ b/services/py-api/src/server/schemas/jwt_schemas/jwt_user_data_schema.py
@@ -14,8 +14,12 @@ class BaseTypedDict(TypedDict):
 # All the types within this should be required
 class JwtUserData(BaseTypedDict):
     sub: str
-    is_admin: bool
-    team_name: str
-    team_id: str
-    is_invite: bool
     exp: float
+
+
+class JwtUserVerification(JwtUserData):
+    is_admin: bool
+
+
+class JwtUserRegistration(JwtUserData):
+    team_id: str

--- a/services/py-api/src/server/schemas/jwt_schemas/schemas.py
+++ b/services/py-api/src/server/schemas/jwt_schemas/schemas.py
@@ -17,9 +17,9 @@ class JwtBase(BaseTypedDict):
     exp: float
 
 
-class JwtParticipantVerification(JwtBase):
+class JwtParticipantVerificationData(JwtBase):
     is_admin: bool
 
 
-class JwtParticipantInviteRegistration(JwtBase):
+class JwtParticipantInviteRegistrationData(JwtBase):
     team_id: str

--- a/services/py-api/src/server/schemas/jwt_schemas/schemas.py
+++ b/services/py-api/src/server/schemas/jwt_schemas/schemas.py
@@ -12,14 +12,14 @@ class BaseTypedDict(TypedDict):
 
 
 # All the types within this should be required
-class JwtUserData(BaseTypedDict):
+class JwtBase(BaseTypedDict):
     sub: str
     exp: float
 
 
-class JwtUserVerification(JwtUserData):
+class JwtParticipantVerification(JwtBase):
     is_admin: bool
 
 
-class JwtUserRegistration(JwtUserData):
+class JwtParticipantInviteRegistration(JwtBase):
     team_id: str

--- a/services/py-api/src/server/schemas/request_schemas/schemas.py
+++ b/services/py-api/src/server/schemas/request_schemas/schemas.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional, Union
+from typing import Literal, Union
 from pydantic import EmailStr, BaseModel, Field, ConfigDict
 
 
@@ -34,12 +34,3 @@ class ParticipantRequestBody(BaseModel):
     registration_info: Union[AdminParticipantInputData, InviteLinkParticipantInputData, RandomParticipantInputData] = (
         Field(discriminator="registration_type")
     )
-
-
-# TODO: Finish implementing the model below
-class UpdateParticipantParams(BaseModel):
-    name: Optional[str]
-    email: Optional[EmailStr]
-    email_verified: Optional[bool]
-    is_admin: Optional[bool]
-    team_name: Optional[str]

--- a/services/py-api/src/server/schemas/response_schemas/schemas.py
+++ b/services/py-api/src/server/schemas/response_schemas/schemas.py
@@ -71,6 +71,12 @@ class ParticipantDeletedResponse(BaseModel):
         return participant.dump_as_json()
 
 
+class ParticipantVerifiedResponse(ParticipantRegisteredResponse):
+    """This response includes the updated body of the verified participant
+    and the body of the verified team in case we are verifying an admin participant.
+    """
+
+
 class TeamDeletedResponse(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 

--- a/services/py-api/src/service/hackathon_service.py
+++ b/services/py-api/src/service/hackathon_service.py
@@ -2,7 +2,7 @@ from math import ceil
 from typing import Optional, Tuple
 
 from motor.motor_asyncio import AsyncIOMotorClientSession
-from result import is_err, Ok, Result
+from result import Err, is_err, Ok, Result
 
 from src.database.model.participant_model import Participant, UpdatedParticipant
 from src.database.model.team_model import Team
@@ -13,9 +13,10 @@ from src.server.exception import (
     DuplicateTeamNameError,
     DuplicateEmailError,
     ParticipantNotFoundError,
+    TeamNameMissmatchError,
     TeamNotFoundError,
 )
-from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserData
+from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserRegistration, JwtUserVerification
 from src.server.schemas.request_schemas.schemas import (
     RandomParticipantInputData,
     AdminParticipantInputData,
@@ -88,13 +89,18 @@ class HackathonService:
         return Ok((result.ok_value, None))
 
     async def create_invite_link_participant(
-        self, input_data: InviteLinkParticipantInputData, decoded_jwt_token: JwtUserData
-    ) -> Result[Tuple[Participant, Team], DuplicateEmailError | TeamNotFoundError | Exception]:
+        self, input_data: InviteLinkParticipantInputData, decoded_jwt_token: JwtUserRegistration
+    ) -> Result[Tuple[Participant, Team], DuplicateEmailError | TeamNotFoundError | TeamNameMissmatchError | Exception]:
 
         # Check if team still exists - Returns an error when it doesn't
-        team_result = await self._team_repo.fetch_by_team_name(input_data.team_name)
+        team_result = await self._team_repo.fetch_by_id(decoded_jwt_token["team_id"])
         if is_err(team_result):
             return team_result
+
+        # Check if the team_name from the token is consistent with the team_name from the request body
+        # A missmatch could occur if the frontend passes something different
+        if input_data.team_name != team_result.ok_value.name:
+            return Err(TeamNameMissmatchError())
 
         participant_result = await self._participant_repo.create(
             Participant(
@@ -158,7 +164,7 @@ class HackathonService:
         return registered_teammates + 1 <= self._team_repo.MAX_NUMBER_OF_TEAM_MEMBERS
 
     async def verify_random_participant(
-        self, jwt_data: JwtUserData
+        self, jwt_data: JwtUserVerification
     ) -> Result[Tuple[Participant, None], ParticipantNotFoundError | Exception]:
 
         # Updates the random participant if it exists

--- a/services/py-api/src/service/hackathon_service.py
+++ b/services/py-api/src/service/hackathon_service.py
@@ -16,7 +16,7 @@ from src.server.exception import (
     TeamNameMissmatchError,
     TeamNotFoundError,
 )
-from src.server.schemas.jwt_schemas.schemas import JwtParticipantInviteRegistration, JwtParticipantVerification
+from src.server.schemas.jwt_schemas.schemas import JwtParticipantInviteRegistrationData, JwtParticipantVerificationData
 from src.server.schemas.request_schemas.schemas import (
     RandomParticipantInputData,
     AdminParticipantInputData,
@@ -89,7 +89,7 @@ class HackathonService:
         return Ok((result.ok_value, None))
 
     async def create_invite_link_participant(
-        self, input_data: InviteLinkParticipantInputData, decoded_jwt_token: JwtParticipantInviteRegistration
+        self, input_data: InviteLinkParticipantInputData, decoded_jwt_token: JwtParticipantInviteRegistrationData
     ) -> Result[Tuple[Participant, Team], DuplicateEmailError | TeamNotFoundError | TeamNameMissmatchError | Exception]:
 
         # Check if team still exists - Returns an error when it doesn't
@@ -164,7 +164,7 @@ class HackathonService:
         return registered_teammates + 1 <= self._team_repo.MAX_NUMBER_OF_TEAM_MEMBERS
 
     async def verify_random_participant(
-        self, jwt_data: JwtParticipantVerification
+        self, jwt_data: JwtParticipantVerificationData
     ) -> Result[Tuple[Participant, None], ParticipantNotFoundError | Exception]:
 
         # Updates the random participant if it exists

--- a/services/py-api/src/service/hackathon_service.py
+++ b/services/py-api/src/service/hackathon_service.py
@@ -16,7 +16,7 @@ from src.server.exception import (
     TeamNameMissmatchError,
     TeamNotFoundError,
 )
-from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserRegistration, JwtUserVerification
+from src.server.schemas.jwt_schemas.schemas import JwtParticipantInviteRegistration, JwtParticipantVerification
 from src.server.schemas.request_schemas.schemas import (
     RandomParticipantInputData,
     AdminParticipantInputData,
@@ -89,7 +89,7 @@ class HackathonService:
         return Ok((result.ok_value, None))
 
     async def create_invite_link_participant(
-        self, input_data: InviteLinkParticipantInputData, decoded_jwt_token: JwtUserRegistration
+        self, input_data: InviteLinkParticipantInputData, decoded_jwt_token: JwtParticipantInviteRegistration
     ) -> Result[Tuple[Participant, Team], DuplicateEmailError | TeamNotFoundError | TeamNameMissmatchError | Exception]:
 
         # Check if team still exists - Returns an error when it doesn't
@@ -164,7 +164,7 @@ class HackathonService:
         return registered_teammates + 1 <= self._team_repo.MAX_NUMBER_OF_TEAM_MEMBERS
 
     async def verify_random_participant(
-        self, jwt_data: JwtUserVerification
+        self, jwt_data: JwtParticipantVerification
     ) -> Result[Tuple[Participant, None], ParticipantNotFoundError | Exception]:
 
         # Updates the random participant if it exists

--- a/services/py-api/src/service/participants_registration_service.py
+++ b/services/py-api/src/service/participants_registration_service.py
@@ -11,7 +11,7 @@ from src.server.exception import (
     TeamCapacityExceededError,
     TeamNameMissmatchError,
 )
-from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserData
+from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserRegistration
 from src.server.schemas.request_schemas.schemas import (
     AdminParticipantInputData,
     RandomParticipantInputData,
@@ -58,16 +58,11 @@ class ParticipantRegistrationService:
         DuplicateEmailError | DuplicateTeamNameError | TeamCapacityExceededError | TeamNameMissmatchError | Exception,
     ]:
         # Decode the token
-        decoded_result = JwtUtility.decode_data(token=jwt_token, schema=JwtUserData)
+        decoded_result = JwtUtility.decode_data(token=jwt_token, schema=JwtUserRegistration)
         if is_err(decoded_result):
             return decoded_result
 
         decoded_data = decoded_result.ok_value
-
-        # Check if the team_name from the token is consistent with the team_name from the request body
-        # A missmatch could occur if the frontend passes something different
-        if input_data.team_name != decoded_data["team_name"]:
-            return Err(TeamNameMissmatchError())
 
         # Check Team Capacity
         has_capacity = await self._hackathon_service.check_team_capacity(decoded_data["team_id"])

--- a/services/py-api/src/service/participants_registration_service.py
+++ b/services/py-api/src/service/participants_registration_service.py
@@ -11,7 +11,7 @@ from src.server.exception import (
     TeamCapacityExceededError,
     TeamNameMissmatchError,
 )
-from src.server.schemas.jwt_schemas.schemas import JwtParticipantInviteRegistration
+from src.server.schemas.jwt_schemas.schemas import JwtParticipantInviteRegistrationData
 from src.server.schemas.request_schemas.schemas import (
     AdminParticipantInputData,
     RandomParticipantInputData,
@@ -58,7 +58,7 @@ class ParticipantRegistrationService:
         DuplicateEmailError | DuplicateTeamNameError | TeamCapacityExceededError | TeamNameMissmatchError | Exception,
     ]:
         # Decode the token
-        decoded_result = JwtUtility.decode_data(token=jwt_token, schema=JwtParticipantInviteRegistration)
+        decoded_result = JwtUtility.decode_data(token=jwt_token, schema=JwtParticipantInviteRegistrationData)
         if is_err(decoded_result):
             return decoded_result
 

--- a/services/py-api/src/service/participants_registration_service.py
+++ b/services/py-api/src/service/participants_registration_service.py
@@ -11,7 +11,7 @@ from src.server.exception import (
     TeamCapacityExceededError,
     TeamNameMissmatchError,
 )
-from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserRegistration
+from src.server.schemas.jwt_schemas.schemas import JwtParticipantInviteRegistration
 from src.server.schemas.request_schemas.schemas import (
     AdminParticipantInputData,
     RandomParticipantInputData,
@@ -58,7 +58,7 @@ class ParticipantRegistrationService:
         DuplicateEmailError | DuplicateTeamNameError | TeamCapacityExceededError | TeamNameMissmatchError | Exception,
     ]:
         # Decode the token
-        decoded_result = JwtUtility.decode_data(token=jwt_token, schema=JwtUserRegistration)
+        decoded_result = JwtUtility.decode_data(token=jwt_token, schema=JwtParticipantInviteRegistration)
         if is_err(decoded_result):
             return decoded_result
 

--- a/services/py-api/src/service/participants_verification_service.py
+++ b/services/py-api/src/service/participants_verification_service.py
@@ -2,7 +2,7 @@ from typing import Tuple
 from result import Err, Result
 from src.database.model.participant_model import Participant
 from src.server.exception import HackathonCapacityExceededError, ParticipantNotFoundError
-from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserVerification
+from src.server.schemas.jwt_schemas.schemas import JwtParticipantVerification
 from src.service.hackathon_service import HackathonService
 
 
@@ -12,7 +12,7 @@ class ParticipantVerificationService:
     def __init__(self, hackathon_service: HackathonService) -> None:
         self._hackathon_service = hackathon_service
 
-    async def verify_random_participant(self, jwt_data: JwtUserVerification) -> Result[
+    async def verify_random_participant(self, jwt_data: JwtParticipantVerification) -> Result[
         Tuple[Participant, None],
         HackathonCapacityExceededError | ParticipantNotFoundError | Exception,
     ]:

--- a/services/py-api/src/service/participants_verification_service.py
+++ b/services/py-api/src/service/participants_verification_service.py
@@ -2,7 +2,7 @@ from typing import Tuple
 from result import Err, Result
 from src.database.model.participant_model import Participant
 from src.server.exception import HackathonCapacityExceededError, ParticipantNotFoundError
-from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserData
+from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserVerification
 from src.service.hackathon_service import HackathonService
 
 
@@ -12,7 +12,7 @@ class ParticipantVerificationService:
     def __init__(self, hackathon_service: HackathonService) -> None:
         self._hackathon_service = hackathon_service
 
-    async def verify_random_participant(self, jwt_data: JwtUserData) -> Result[
+    async def verify_random_participant(self, jwt_data: JwtUserVerification) -> Result[
         Tuple[Participant, None],
         HackathonCapacityExceededError | ParticipantNotFoundError | Exception,
     ]:

--- a/services/py-api/src/service/participants_verification_service.py
+++ b/services/py-api/src/service/participants_verification_service.py
@@ -1,0 +1,23 @@
+from typing import Tuple
+from result import Err, Result
+from src.database.model.participant_model import Participant
+from src.server.exception import HackathonCapacityExceededError, ParticipantNotFoundError
+from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserData
+from src.service.hackathon_service import HackathonService
+
+
+class ParticipantVerificationService:
+    """Service layer responsible for handling the business logic when verifying a participant"""
+
+    def __init__(self, hackathon_service: HackathonService) -> None:
+        self._hackathon_service = hackathon_service
+
+    async def verify_random_participant(self, jwt_data: JwtUserData) -> Result[
+        Tuple[Participant, None],
+        HackathonCapacityExceededError | ParticipantNotFoundError | Exception,
+    ]:
+        has_capacity = await self._hackathon_service.check_capacity_register_random_participant_case()
+        if not has_capacity:
+            return Err(HackathonCapacityExceededError())
+
+        return await self._hackathon_service.verify_random_participant(jwt_data=jwt_data)

--- a/services/py-api/src/service/participants_verification_service.py
+++ b/services/py-api/src/service/participants_verification_service.py
@@ -2,7 +2,7 @@ from typing import Tuple
 from result import Err, Result
 from src.database.model.participant_model import Participant
 from src.server.exception import HackathonCapacityExceededError, ParticipantNotFoundError
-from src.server.schemas.jwt_schemas.schemas import JwtParticipantVerification
+from src.server.schemas.jwt_schemas.schemas import JwtParticipantVerificationData
 from src.service.hackathon_service import HackathonService
 
 
@@ -12,7 +12,7 @@ class ParticipantVerificationService:
     def __init__(self, hackathon_service: HackathonService) -> None:
         self._hackathon_service = hackathon_service
 
-    async def verify_random_participant(self, jwt_data: JwtParticipantVerification) -> Result[
+    async def verify_random_participant(self, jwt_data: JwtParticipantVerificationData) -> Result[
         Tuple[Participant, None],
         HackathonCapacityExceededError | ParticipantNotFoundError | Exception,
     ]:

--- a/services/py-api/src/utils.py
+++ b/services/py-api/src/utils.py
@@ -13,7 +13,7 @@ import httpx
 from result import Err, Ok, Result
 from structlog.stdlib import get_logger
 
-from src.server.schemas.jwt_schemas.jwt_user_data_schema import BaseTypedDict
+from src.server.schemas.jwt_schemas.schemas import BaseTypedDict
 
 LOG = get_logger()
 

--- a/services/py-api/tests/integration_tests/conftest.py
+++ b/services/py-api/tests/integration_tests/conftest.py
@@ -10,7 +10,9 @@ from os import environ
 LOG = get_logger()
 
 PARTICIPANT_ENDPOINT_URL = "/api/v3/hackathon/participants"
+PARTICIPANT_VERIFY_URL = "/api/v3/hackathon/participants/verify"
 TEAM_ENDPOINT_URL = "/api/v3/hackathon/teams"
+
 TEST_USER_NAME = "Test User"
 TEST_TEAM_NAME = "Test Team"
 TEST_USER_EMAIL = "test@test.com"

--- a/services/py-api/tests/integration_tests/conftest.py
+++ b/services/py-api/tests/integration_tests/conftest.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 import pytest
 import pytest_asyncio
@@ -181,3 +182,8 @@ def generate_participant_request_body() -> ParticipantRequestBodyCallable:
 @pytest.fixture
 def mock_obj_id() -> str:
     return "507f1f77bcf86cd799439011"
+
+
+@pytest.fixture
+def thirty_sec_jwt_exp_limit() -> float:
+    return (datetime.now(tz=timezone.utc) + timedelta(seconds=30)).timestamp()

--- a/services/py-api/tests/integration_tests/test_jwt_utility.py
+++ b/services/py-api/tests/integration_tests/test_jwt_utility.py
@@ -2,7 +2,7 @@ import os
 from unittest.mock import patch
 from result import Err, Ok
 from src.server.exception import JwtDecodeSchemaMismatch, JwtExpiredSignatureError, JwtInvalidSignatureError
-from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserData, JwtUserVerification
+from src.server.schemas.jwt_schemas.schemas import JwtBase, JwtParticipantVerification
 from datetime import datetime, timedelta, timezone
 from src.utils import JwtUtility
 
@@ -12,11 +12,11 @@ instant_expiration_time = (datetime.now(tz=timezone.utc)).timestamp()
 
 @patch.dict("os.environ", {"SECRET_KEY": "abcdefghijklmnopqrst"})
 def test_encode_decode_success(mock_obj_id: str) -> None:
-    payload = JwtUserData(sub=mock_obj_id, exp=sufficient_expiration_time)
+    payload = JwtBase(sub=mock_obj_id, exp=sufficient_expiration_time)
     encoded_data = JwtUtility.encode_data(data=payload)
     assert isinstance(encoded_data, str)
 
-    decoded_data = JwtUtility.decode_data(token=encoded_data, schema=JwtUserData)
+    decoded_data = JwtUtility.decode_data(token=encoded_data, schema=JwtBase)
     assert isinstance(decoded_data, Ok)
     assert decoded_data.ok_value == payload
 
@@ -24,10 +24,10 @@ def test_encode_decode_success(mock_obj_id: str) -> None:
 @patch.dict("os.environ", {"SECRET_KEY": "abcdefghijklmnopqrst"})
 def test_encode_failure_missing_keys(mock_obj_id: str) -> None:
     """Tests the case when the token is encoded with a schema that has less keys than our target"""
-    encoded_data = JwtUtility.encode_data(data=JwtUserData(sub=mock_obj_id, exp=sufficient_expiration_time))
+    encoded_data = JwtUtility.encode_data(data=JwtBase(sub=mock_obj_id, exp=sufficient_expiration_time))
     assert isinstance(encoded_data, str)
 
-    decoded_data = JwtUtility.decode_data(token=encoded_data, schema=JwtUserVerification)
+    decoded_data = JwtUtility.decode_data(token=encoded_data, schema=JwtParticipantVerification)
     assert isinstance(decoded_data, Err)
     assert isinstance(decoded_data.err_value, JwtDecodeSchemaMismatch)
 
@@ -36,21 +36,21 @@ def test_encode_failure_missing_keys(mock_obj_id: str) -> None:
 def test_encode_failure_additional_keys(mock_obj_id: str) -> None:
     """Tests the case when the token is encoded with a schema that has more keys than our target"""
     encoded_data = JwtUtility.encode_data(
-        data=JwtUserVerification(sub=mock_obj_id, is_admin=True, exp=sufficient_expiration_time)
+        data=JwtParticipantVerification(sub=mock_obj_id, is_admin=True, exp=sufficient_expiration_time)
     )
     assert isinstance(encoded_data, str)
 
-    decoded_data = JwtUtility.decode_data(token=encoded_data, schema=JwtUserData)
+    decoded_data = JwtUtility.decode_data(token=encoded_data, schema=JwtBase)
     assert isinstance(decoded_data, Err)
     assert isinstance(decoded_data.err_value, JwtDecodeSchemaMismatch)
 
 
 @patch.dict("os.environ", {"SECRET_KEY": "abcdefghijklmnopqrst"})
 def test_decode_failure_expired_token(mock_obj_id: str) -> None:
-    encoded_data = JwtUtility.encode_data(data=JwtUserData(sub=mock_obj_id, exp=instant_expiration_time))
+    encoded_data = JwtUtility.encode_data(data=JwtBase(sub=mock_obj_id, exp=instant_expiration_time))
     assert isinstance(encoded_data, str)
 
-    decoded_data = JwtUtility.decode_data(token=encoded_data, schema=JwtUserData)
+    decoded_data = JwtUtility.decode_data(token=encoded_data, schema=JwtBase)
     assert isinstance(decoded_data, Err)
     assert isinstance(decoded_data.err_value, JwtExpiredSignatureError)
 
@@ -58,11 +58,11 @@ def test_decode_failure_expired_token(mock_obj_id: str) -> None:
 def test_encode_decode_secret_key_mismatch(mock_obj_id: str) -> None:
     # Mock the SECRET_KEY environment variable for encoding
     with patch.dict(os.environ, {"SECRET_KEY": "abcdefghijklmnopqrst"}):
-        encoded_data = JwtUtility.encode_data(data=JwtUserData(sub=mock_obj_id, exp=sufficient_expiration_time))
+        encoded_data = JwtUtility.encode_data(data=JwtBase(sub=mock_obj_id, exp=sufficient_expiration_time))
         assert isinstance(encoded_data, str)  # Verify token is a string
 
     # Mock a different SECRET_KEY environment variable for decoding
     with patch.dict(os.environ, {"SECRET_KEY": "tsrqponmlkjihgfedcab"}):
-        decoded_data = JwtUtility.decode_data(token=encoded_data, schema=JwtUserData)
+        decoded_data = JwtUtility.decode_data(token=encoded_data, schema=JwtBase)
         assert isinstance(decoded_data, Err)  # Ensure the result is an error object
         assert isinstance(decoded_data.err_value, JwtInvalidSignatureError)

--- a/services/py-api/tests/integration_tests/test_jwt_utility.py
+++ b/services/py-api/tests/integration_tests/test_jwt_utility.py
@@ -3,16 +3,13 @@ from unittest.mock import patch
 from result import Err, Ok
 from src.server.exception import JwtDecodeSchemaMismatch, JwtExpiredSignatureError, JwtInvalidSignatureError
 from src.server.schemas.jwt_schemas.schemas import JwtBase, JwtParticipantVerification
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from src.utils import JwtUtility
-
-sufficient_expiration_time = (datetime.now(tz=timezone.utc) + timedelta(seconds=30)).timestamp()
-instant_expiration_time = (datetime.now(tz=timezone.utc)).timestamp()
 
 
 @patch.dict("os.environ", {"SECRET_KEY": "abcdefghijklmnopqrst"})
-def test_encode_decode_success(mock_obj_id: str) -> None:
-    payload = JwtBase(sub=mock_obj_id, exp=sufficient_expiration_time)
+def test_encode_decode_success(mock_obj_id: str, thirty_sec_jwt_exp_limit: float) -> None:
+    payload = JwtBase(sub=mock_obj_id, exp=thirty_sec_jwt_exp_limit)
     encoded_data = JwtUtility.encode_data(data=payload)
     assert isinstance(encoded_data, str)
 
@@ -22,9 +19,9 @@ def test_encode_decode_success(mock_obj_id: str) -> None:
 
 
 @patch.dict("os.environ", {"SECRET_KEY": "abcdefghijklmnopqrst"})
-def test_encode_failure_missing_keys(mock_obj_id: str) -> None:
+def test_encode_failure_missing_keys(mock_obj_id: str, thirty_sec_jwt_exp_limit: float) -> None:
     """Tests the case when the token is encoded with a schema that has less keys than our target"""
-    encoded_data = JwtUtility.encode_data(data=JwtBase(sub=mock_obj_id, exp=sufficient_expiration_time))
+    encoded_data = JwtUtility.encode_data(data=JwtBase(sub=mock_obj_id, exp=thirty_sec_jwt_exp_limit))
     assert isinstance(encoded_data, str)
 
     decoded_data = JwtUtility.decode_data(token=encoded_data, schema=JwtParticipantVerification)
@@ -33,10 +30,10 @@ def test_encode_failure_missing_keys(mock_obj_id: str) -> None:
 
 
 @patch.dict("os.environ", {"SECRET_KEY": "abcdefghijklmnopqrst"})
-def test_encode_failure_additional_keys(mock_obj_id: str) -> None:
+def test_encode_failure_additional_keys(mock_obj_id: str, thirty_sec_jwt_exp_limit: float) -> None:
     """Tests the case when the token is encoded with a schema that has more keys than our target"""
     encoded_data = JwtUtility.encode_data(
-        data=JwtParticipantVerification(sub=mock_obj_id, is_admin=True, exp=sufficient_expiration_time)
+        data=JwtParticipantVerification(sub=mock_obj_id, is_admin=True, exp=thirty_sec_jwt_exp_limit)
     )
     assert isinstance(encoded_data, str)
 
@@ -47,7 +44,9 @@ def test_encode_failure_additional_keys(mock_obj_id: str) -> None:
 
 @patch.dict("os.environ", {"SECRET_KEY": "abcdefghijklmnopqrst"})
 def test_decode_failure_expired_token(mock_obj_id: str) -> None:
-    encoded_data = JwtUtility.encode_data(data=JwtBase(sub=mock_obj_id, exp=instant_expiration_time))
+    encoded_data = JwtUtility.encode_data(
+        data=JwtBase(sub=mock_obj_id, exp=(datetime.now(tz=timezone.utc)).timestamp())
+    )
     assert isinstance(encoded_data, str)
 
     decoded_data = JwtUtility.decode_data(token=encoded_data, schema=JwtBase)
@@ -55,10 +54,10 @@ def test_decode_failure_expired_token(mock_obj_id: str) -> None:
     assert isinstance(decoded_data.err_value, JwtExpiredSignatureError)
 
 
-def test_encode_decode_secret_key_mismatch(mock_obj_id: str) -> None:
+def test_encode_decode_secret_key_mismatch(mock_obj_id: str, thirty_sec_jwt_exp_limit: float) -> None:
     # Mock the SECRET_KEY environment variable for encoding
     with patch.dict(os.environ, {"SECRET_KEY": "abcdefghijklmnopqrst"}):
-        encoded_data = JwtUtility.encode_data(data=JwtBase(sub=mock_obj_id, exp=sufficient_expiration_time))
+        encoded_data = JwtUtility.encode_data(data=JwtBase(sub=mock_obj_id, exp=thirty_sec_jwt_exp_limit))
         assert isinstance(encoded_data, str)  # Verify token is a string
 
     # Mock a different SECRET_KEY environment variable for decoding

--- a/services/py-api/tests/integration_tests/test_jwt_utility.py
+++ b/services/py-api/tests/integration_tests/test_jwt_utility.py
@@ -2,53 +2,42 @@ import os
 from unittest.mock import patch
 from result import Err, Ok
 from src.server.exception import JwtDecodeSchemaMismatch, JwtExpiredSignatureError, JwtInvalidSignatureError
-from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserData
+from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserData, JwtUserVerification
 from datetime import datetime, timedelta, timezone
 from src.utils import JwtUtility
 
 sufficient_expiration_time = (datetime.now(tz=timezone.utc) + timedelta(seconds=30)).timestamp()
 instant_expiration_time = (datetime.now(tz=timezone.utc)).timestamp()
 
-CORRECT_TEST_PAYLOAD = JwtUserData(
-    sub="alksdjflksd987fsidjf98sduf",
-    is_admin=True,
-    team_id="slkdjflkasjdflkjsdlkj",
-    team_name="asdkjlfksj",
-    is_invite=False,
-    exp=sufficient_expiration_time,
-)
-
-MISSING_KEY_TEST_PAYLOAD = JwtUserData(  # We need it only for testing purposes | mypy complains
-    sub="alksdjflksd987fsidjf98sduf", is_admin=True, team_id="slkdjflkasjdflkjsdlkj", team_name="asdkjlfksj", is_invite=False  # type: ignore
-)
-
-ADDITIONAL_KEY_TEST_PAYLOAD = JwtUserData(
-    sub="alksdjflksd987fsidjf98sduf", is_admin=True, team_id="slkdjflkasjdflkjsdlkj", team_name="asdkjlfksj", is_invite=False, exp=sufficient_expiration_time, name="abcdefgji"  # type: ignore
-)
-
-EXPIRED_TEST_PAYLOAD = JwtUserData(
-    sub="alksdjflksd987fsidjf98sduf",
-    is_admin=True,
-    team_id="slkdjflkasjdflkjsdlkj",
-    team_name="asdkjlfksj",
-    is_invite=False,
-    exp=instant_expiration_time,
-)
-
 
 @patch.dict("os.environ", {"SECRET_KEY": "abcdefghijklmnopqrst"})
-def test_encode_decode_success() -> None:
-    encoded_data = JwtUtility.encode_data(data=CORRECT_TEST_PAYLOAD)
+def test_encode_decode_success(mock_obj_id: str) -> None:
+    payload = JwtUserData(sub=mock_obj_id, exp=sufficient_expiration_time)
+    encoded_data = JwtUtility.encode_data(data=payload)
     assert isinstance(encoded_data, str)
 
     decoded_data = JwtUtility.decode_data(token=encoded_data, schema=JwtUserData)
     assert isinstance(decoded_data, Ok)
-    assert decoded_data.ok_value == CORRECT_TEST_PAYLOAD
+    assert decoded_data.ok_value == payload
 
 
 @patch.dict("os.environ", {"SECRET_KEY": "abcdefghijklmnopqrst"})
-def test_encode_failure_missing_keys() -> None:
-    encoded_data = JwtUtility.encode_data(data=MISSING_KEY_TEST_PAYLOAD)
+def test_encode_failure_missing_keys(mock_obj_id: str) -> None:
+    """Tests the case when the token is encoded with a schema that has less keys than our target"""
+    encoded_data = JwtUtility.encode_data(data=JwtUserData(sub=mock_obj_id, exp=sufficient_expiration_time))
+    assert isinstance(encoded_data, str)
+
+    decoded_data = JwtUtility.decode_data(token=encoded_data, schema=JwtUserVerification)
+    assert isinstance(decoded_data, Err)
+    assert isinstance(decoded_data.err_value, JwtDecodeSchemaMismatch)
+
+
+@patch.dict("os.environ", {"SECRET_KEY": "abcdefghijklmnopqrst"})
+def test_encode_failure_additional_keys(mock_obj_id: str) -> None:
+    """Tests the case when the token is encoded with a schema that has more keys than our target"""
+    encoded_data = JwtUtility.encode_data(
+        data=JwtUserVerification(sub=mock_obj_id, is_admin=True, exp=sufficient_expiration_time)
+    )
     assert isinstance(encoded_data, str)
 
     decoded_data = JwtUtility.decode_data(token=encoded_data, schema=JwtUserData)
@@ -57,18 +46,8 @@ def test_encode_failure_missing_keys() -> None:
 
 
 @patch.dict("os.environ", {"SECRET_KEY": "abcdefghijklmnopqrst"})
-def test_encode_failure_additional_keys() -> None:
-    encoded_data = JwtUtility.encode_data(data=ADDITIONAL_KEY_TEST_PAYLOAD)
-    assert isinstance(encoded_data, str)
-
-    decoded_data = JwtUtility.decode_data(token=encoded_data, schema=JwtUserData)
-    assert isinstance(decoded_data, Err)
-    assert isinstance(decoded_data.err_value, JwtDecodeSchemaMismatch)
-
-
-@patch.dict("os.environ", {"SECRET_KEY": "abcdefghijklmnopqrst"})
-def test_decode_failure_expired_token() -> None:
-    encoded_data = JwtUtility.encode_data(data=EXPIRED_TEST_PAYLOAD)
+def test_decode_failure_expired_token(mock_obj_id: str) -> None:
+    encoded_data = JwtUtility.encode_data(data=JwtUserData(sub=mock_obj_id, exp=instant_expiration_time))
     assert isinstance(encoded_data, str)
 
     decoded_data = JwtUtility.decode_data(token=encoded_data, schema=JwtUserData)
@@ -76,10 +55,10 @@ def test_decode_failure_expired_token() -> None:
     assert isinstance(decoded_data.err_value, JwtExpiredSignatureError)
 
 
-def test_encode_decode_secret_key_mismatch() -> None:
+def test_encode_decode_secret_key_mismatch(mock_obj_id: str) -> None:
     # Mock the SECRET_KEY environment variable for encoding
     with patch.dict(os.environ, {"SECRET_KEY": "abcdefghijklmnopqrst"}):
-        encoded_data = JwtUtility.encode_data(data=CORRECT_TEST_PAYLOAD)
+        encoded_data = JwtUtility.encode_data(data=JwtUserData(sub=mock_obj_id, exp=sufficient_expiration_time))
         assert isinstance(encoded_data, str)  # Verify token is a string
 
     # Mock a different SECRET_KEY environment variable for decoding

--- a/services/py-api/tests/integration_tests/test_jwt_utility.py
+++ b/services/py-api/tests/integration_tests/test_jwt_utility.py
@@ -2,7 +2,7 @@ import os
 from unittest.mock import patch
 from result import Err, Ok
 from src.server.exception import JwtDecodeSchemaMismatch, JwtExpiredSignatureError, JwtInvalidSignatureError
-from src.server.schemas.jwt_schemas.schemas import JwtBase, JwtParticipantVerification
+from src.server.schemas.jwt_schemas.schemas import JwtBase, JwtParticipantVerificationData
 from datetime import datetime, timezone
 from src.utils import JwtUtility
 
@@ -24,7 +24,7 @@ def test_encode_failure_missing_keys(mock_obj_id: str, thirty_sec_jwt_exp_limit:
     encoded_data = JwtUtility.encode_data(data=JwtBase(sub=mock_obj_id, exp=thirty_sec_jwt_exp_limit))
     assert isinstance(encoded_data, str)
 
-    decoded_data = JwtUtility.decode_data(token=encoded_data, schema=JwtParticipantVerification)
+    decoded_data = JwtUtility.decode_data(token=encoded_data, schema=JwtParticipantVerificationData)
     assert isinstance(decoded_data, Err)
     assert isinstance(decoded_data.err_value, JwtDecodeSchemaMismatch)
 
@@ -33,7 +33,7 @@ def test_encode_failure_missing_keys(mock_obj_id: str, thirty_sec_jwt_exp_limit:
 def test_encode_failure_additional_keys(mock_obj_id: str, thirty_sec_jwt_exp_limit: float) -> None:
     """Tests the case when the token is encoded with a schema that has more keys than our target"""
     encoded_data = JwtUtility.encode_data(
-        data=JwtParticipantVerification(sub=mock_obj_id, is_admin=True, exp=thirty_sec_jwt_exp_limit)
+        data=JwtParticipantVerificationData(sub=mock_obj_id, is_admin=True, exp=thirty_sec_jwt_exp_limit)
     )
     assert isinstance(encoded_data, str)
 

--- a/services/py-api/tests/integration_tests/test_participant_routes.py
+++ b/services/py-api/tests/integration_tests/test_participant_routes.py
@@ -264,6 +264,7 @@ async def test_create_link_participant_succesful(
     assert resp_json["team_id"] == admin_resp_json["team_id"]
 
 
+@patch.object(TeamsRepository, "MAX_NUMBER_OF_TEAM_MEMBERS", 2)
 @patch.dict("os.environ", {"SECRET_KEY": "abcdefghijklmnopqrst"})
 @pytest.mark.asyncio
 async def test_create_link_participant_team_capacity_exceeded(

--- a/services/py-api/tests/integration_tests/test_participant_routes.py
+++ b/services/py-api/tests/integration_tests/test_participant_routes.py
@@ -2,7 +2,7 @@ from os import environ
 from unittest.mock import patch
 from httpx import AsyncClient
 import pytest
-from src.server.schemas.jwt_schemas.schemas import JwtParticipantInviteRegistration
+from src.server.schemas.jwt_schemas.schemas import JwtParticipantInviteRegistrationData
 from tests.integration_tests.conftest import (
     PARTICIPANT_ENDPOINT_URL,
     TEST_TEAM_NAME,
@@ -11,7 +11,6 @@ from tests.integration_tests.conftest import (
     ParticipantRequestBodyCallable,
     CreateTestParticipantCallable,
 )
-from tests.integration_tests.test_jwt_utility import sufficient_expiration_time
 from src.database.repository.teams_repository import TeamsRepository
 from src.utils import JwtUtility
 
@@ -238,6 +237,7 @@ async def test_delete_participant_obj_id_doesnt_exist(async_client: AsyncClient,
 async def test_create_link_participant_succesful(
     create_test_participant: CreateTestParticipantCallable,
     generate_participant_request_body: ParticipantRequestBodyCallable,
+    thirty_sec_jwt_exp_limit: float,
 ) -> None:
     admin_partcipant_body = generate_participant_request_body(
         registration_type="admin", email="testadmin@test.com", is_admin=True, team_name=TEST_TEAM_NAME
@@ -248,10 +248,10 @@ async def test_create_link_participant_succesful(
     admin_resp_json = admin_resp.json()["participant"]
 
     link_participant_body = generate_participant_request_body(registration_type="invite_link", team_name=TEST_TEAM_NAME)
-    jwt_payload = JwtParticipantInviteRegistration(
+    jwt_payload = JwtParticipantInviteRegistrationData(
         sub=admin_resp_json["id"],
         team_id=admin_resp_json["team_id"],
-        exp=sufficient_expiration_time,
+        exp=thirty_sec_jwt_exp_limit,
     )
     encoded_token = JwtUtility.encode_data(data=jwt_payload)
 
@@ -270,6 +270,7 @@ async def test_create_link_participant_succesful(
 async def test_create_link_participant_team_capacity_exceeded(
     create_test_participant: CreateTestParticipantCallable,
     generate_participant_request_body: ParticipantRequestBodyCallable,
+    thirty_sec_jwt_exp_limit: float,
 ) -> None:
     admin_partcipant_body = generate_participant_request_body(
         registration_type="admin", email="testadmin@test.com", is_admin=True, team_name=TEST_TEAM_NAME
@@ -278,10 +279,10 @@ async def test_create_link_participant_team_capacity_exceeded(
     assert admin_resp.status_code == 201
 
     admin_resp_json = admin_resp.json()["participant"]
-    jwt_payload = JwtParticipantInviteRegistration(
+    jwt_payload = JwtParticipantInviteRegistrationData(
         sub=admin_resp_json["id"],
         team_id=admin_resp_json["team_id"],
-        exp=sufficient_expiration_time,
+        exp=thirty_sec_jwt_exp_limit,
     )
     encoded_token = JwtUtility.encode_data(data=jwt_payload)
 
@@ -336,6 +337,7 @@ async def test_create_link_participant_jwt_wrong_format(
 async def test_create_link_participant_team_name_mismatch(
     create_test_participant: CreateTestParticipantCallable,
     generate_participant_request_body: ParticipantRequestBodyCallable,
+    thirty_sec_jwt_exp_limit: float,
 ) -> None:
     admin_partcipant_body = generate_participant_request_body(
         registration_type="admin", email="testadmin@test.com", is_admin=True, team_name=TEST_TEAM_NAME
@@ -346,10 +348,10 @@ async def test_create_link_participant_team_name_mismatch(
     admin_resp_json = admin_resp.json()["participant"]
 
     link_participant_body = generate_participant_request_body(registration_type="invite_link", team_name="testteam1")
-    jwt_payload = JwtParticipantInviteRegistration(
+    jwt_payload = JwtParticipantInviteRegistrationData(
         sub=admin_resp_json["id"],
         team_id=admin_resp_json["team_id"],
-        exp=sufficient_expiration_time,
+        exp=thirty_sec_jwt_exp_limit,
     )
     encoded_token = JwtUtility.encode_data(data=jwt_payload)
 

--- a/services/py-api/tests/integration_tests/test_participant_routes.py
+++ b/services/py-api/tests/integration_tests/test_participant_routes.py
@@ -2,7 +2,7 @@ from os import environ
 from unittest.mock import patch
 from httpx import AsyncClient
 import pytest
-from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserData
+from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserRegistration
 from tests.integration_tests.conftest import (
     PARTICIPANT_ENDPOINT_URL,
     TEST_TEAM_NAME,
@@ -248,11 +248,8 @@ async def test_create_link_participant_succesful(
     admin_resp_json = admin_resp.json()["participant"]
 
     link_participant_body = generate_participant_request_body(registration_type="invite_link", team_name=TEST_TEAM_NAME)
-    jwt_payload = JwtUserData(
+    jwt_payload = JwtUserRegistration(
         sub=admin_resp_json["id"],
-        is_admin=False,
-        team_name=TEST_TEAM_NAME,
-        is_invite=True,
         team_id=admin_resp_json["team_id"],
         exp=sufficient_expiration_time,
     )
@@ -280,11 +277,8 @@ async def test_create_link_participant_team_capacity_exceeded(
     assert admin_resp.status_code == 201
 
     admin_resp_json = admin_resp.json()["participant"]
-    jwt_payload = JwtUserData(
+    jwt_payload = JwtUserRegistration(
         sub=admin_resp_json["id"],
-        is_admin=False,
-        team_name=TEST_TEAM_NAME,
-        is_invite=True,
         team_id=admin_resp_json["team_id"],
         exp=sufficient_expiration_time,
     )
@@ -351,11 +345,8 @@ async def test_create_link_participant_team_name_mismatch(
     admin_resp_json = admin_resp.json()["participant"]
 
     link_participant_body = generate_participant_request_body(registration_type="invite_link", team_name="testteam1")
-    jwt_payload = JwtUserData(
+    jwt_payload = JwtUserRegistration(
         sub=admin_resp_json["id"],
-        is_admin=False,
-        team_name=TEST_TEAM_NAME,
-        is_invite=True,
         team_id=admin_resp_json["team_id"],
         exp=sufficient_expiration_time,
     )
@@ -367,5 +358,5 @@ async def test_create_link_participant_team_name_mismatch(
     resp_json = resp.json()
     assert (
         resp_json["error"]
-        == "team_name passed in the request body is different from the team_name in thedecoded JWT token"
+        == "team_name passed in the request body is different from the team_name in the decoded JWT token"
     )

--- a/services/py-api/tests/integration_tests/test_participant_routes.py
+++ b/services/py-api/tests/integration_tests/test_participant_routes.py
@@ -2,7 +2,7 @@ from os import environ
 from unittest.mock import patch
 from httpx import AsyncClient
 import pytest
-from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserRegistration
+from src.server.schemas.jwt_schemas.schemas import JwtParticipantInviteRegistration
 from tests.integration_tests.conftest import (
     PARTICIPANT_ENDPOINT_URL,
     TEST_TEAM_NAME,
@@ -248,7 +248,7 @@ async def test_create_link_participant_succesful(
     admin_resp_json = admin_resp.json()["participant"]
 
     link_participant_body = generate_participant_request_body(registration_type="invite_link", team_name=TEST_TEAM_NAME)
-    jwt_payload = JwtUserRegistration(
+    jwt_payload = JwtParticipantInviteRegistration(
         sub=admin_resp_json["id"],
         team_id=admin_resp_json["team_id"],
         exp=sufficient_expiration_time,
@@ -278,7 +278,7 @@ async def test_create_link_participant_team_capacity_exceeded(
     assert admin_resp.status_code == 201
 
     admin_resp_json = admin_resp.json()["participant"]
-    jwt_payload = JwtUserRegistration(
+    jwt_payload = JwtParticipantInviteRegistration(
         sub=admin_resp_json["id"],
         team_id=admin_resp_json["team_id"],
         exp=sufficient_expiration_time,
@@ -346,7 +346,7 @@ async def test_create_link_participant_team_name_mismatch(
     admin_resp_json = admin_resp.json()["participant"]
 
     link_participant_body = generate_participant_request_body(registration_type="invite_link", team_name="testteam1")
-    jwt_payload = JwtUserRegistration(
+    jwt_payload = JwtParticipantInviteRegistration(
         sub=admin_resp_json["id"],
         team_id=admin_resp_json["team_id"],
         exp=sufficient_expiration_time,

--- a/services/py-api/tests/integration_tests/test_verification_routes.py
+++ b/services/py-api/tests/integration_tests/test_verification_routes.py
@@ -1,0 +1,114 @@
+from unittest.mock import patch
+from httpx import AsyncClient
+import pytest
+from src.database.repository.teams_repository import TeamsRepository
+from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserVerification
+from src.utils import JwtUtility
+from tests.integration_tests.conftest import CreateTestParticipantCallable, ParticipantRequestBodyCallable
+from tests.integration_tests.test_jwt_utility import sufficient_expiration_time
+from tests.integration_tests.conftest import PARTICIPANT_VERIFY_URL
+from starlette import status
+
+
+@patch.dict("os.environ", {"SECRET_KEY": "abcdefghijklmnopqrst"})
+@pytest.mark.asyncio
+async def test_verify_random_participant_success(
+    create_test_participant: CreateTestParticipantCallable,
+    generate_participant_request_body: ParticipantRequestBodyCallable,
+    async_client: AsyncClient,
+) -> None:
+    # Generate random participant body
+    random_participant_body = generate_participant_request_body(registration_type="random", is_admin=None)
+    # Create random participant
+    create_resp = await create_test_participant(participant_body=random_participant_body)
+    # Assert that the participant was created successfully
+    assert create_resp.status_code == status.HTTP_201_CREATED
+
+    create_resp_json = create_resp.json()
+
+    # Generate jwt token based on the random participant that was created
+    verify_jwt_token_payload = JwtUserVerification(
+        sub=create_resp_json["participant"]["id"], is_admin=False, exp=sufficient_expiration_time
+    )
+    verify_jwt_token = JwtUtility.encode_data(data=verify_jwt_token_payload)
+
+    # Make call to the endpoint to verify participant
+    verify_resp = await async_client.patch(url=f"{PARTICIPANT_VERIFY_URL}?jwt_token={verify_jwt_token}")
+
+    # Assert that the verification was successful
+    assert verify_resp.status_code == status.HTTP_200_OK
+
+    verify_resp_json = verify_resp.json()
+    # Assert that this is the random participant that we created and the is_verify field is now true
+    assert verify_resp_json["participant"]["id"] == create_resp_json["participant"]["id"]
+    assert verify_resp_json["participant"]["name"] == create_resp_json["participant"]["name"]
+    assert verify_resp_json["participant"]["email"] == create_resp_json["participant"]["email"]
+    assert verify_resp_json["participant"]["is_admin"] == create_resp_json["participant"]["is_admin"]
+    assert create_resp_json["participant"]["email_verified"] is False
+    assert verify_resp_json["participant"]["email_verified"] is True
+    assert create_resp_json["team"] is None
+    assert verify_resp_json["team"] is None
+
+
+@patch.dict("os.environ", {"SECRET_KEY": "abcdefghijklmnopqrst"})
+@pytest.mark.asyncio
+async def test_verify_random_participant_not_found(async_client: AsyncClient, mock_obj_id: str) -> None:
+
+    # Generate jwt token based on a mock object id that does not exist on the database
+    verify_jwt_token_payload = JwtUserVerification(sub=mock_obj_id, is_admin=False, exp=sufficient_expiration_time)
+    verify_jwt_token = JwtUtility.encode_data(data=verify_jwt_token_payload)
+
+    # Make call to the endpoint to verify participant
+    verify_resp = await async_client.patch(url=f"{PARTICIPANT_VERIFY_URL}?jwt_token={verify_jwt_token}")
+
+    # Assert that the verification was not successful. The participant that we are trying to verify is missing
+    assert verify_resp.status_code == status.HTTP_404_NOT_FOUND
+
+    verify_resp_json = verify_resp.json()
+    # Check the error message
+    assert verify_resp_json["error"] == "The specified participant was not found"
+
+
+@patch.object(TeamsRepository, "MAX_NUMBER_OF_TEAM_MEMBERS", 2)
+@patch.object(TeamsRepository, "MAX_NUMBER_OF_VERIFIED_TEAMS_IN_HACKATHON", 1)
+@patch.dict("os.environ", {"SECRET_KEY": "abcdefghijklmnopqrst"})
+@pytest.mark.asyncio
+async def test_verify_random_participant_hackathon_capacity_exceeded(
+    create_test_participant: CreateTestParticipantCallable,
+    generate_participant_request_body: ParticipantRequestBodyCallable,
+    async_client: AsyncClient,
+) -> None:
+    # Buffer for the created unverified participants
+    created_participant_ids = []
+
+    # Create 3 unverified random participants - Shows that you can create more unverified random participants than the max cap.
+    for i in range(TeamsRepository.MAX_NUMBER_OF_TEAM_MEMBERS + 1):
+        # Generate random participant body
+        random_participant_body = generate_participant_request_body(
+            registration_type="random", email=f"test{i}@test.com", is_admin=None
+        )
+        # Create random participant
+        create_resp = await create_test_participant(participant_body=random_participant_body)
+        assert create_resp.status_code == status.HTTP_201_CREATED
+
+        create_resp_json = create_resp.json()
+        created_participant_ids.append(create_resp_json["participant"]["id"])
+
+    # We try to verify each of them, but we should only be able to verify up to the capacity
+    for i in range(TeamsRepository.MAX_NUMBER_OF_TEAM_MEMBERS + 1):
+        # Generate jwt token based on a mock object id that does not exist on the database
+        verify_jwt_token_payload = JwtUserVerification(
+            sub=created_participant_ids.pop(), is_admin=False, exp=sufficient_expiration_time
+        )
+        verify_jwt_token = JwtUtility.encode_data(data=verify_jwt_token_payload)
+        # Make call to the endpoint to verify participant
+        verify_resp = await async_client.patch(url=f"{PARTICIPANT_VERIFY_URL}?jwt_token={verify_jwt_token}")
+        verify_resp_json = verify_resp.json()
+
+        # Make assertions conditionally
+        # Verification is successful only up to capacity
+        if i < TeamsRepository.MAX_NUMBER_OF_TEAM_MEMBERS:
+            assert verify_resp.status_code == status.HTTP_200_OK
+        else:
+            assert verify_resp.status_code == status.HTTP_409_CONFLICT
+            assert verify_resp_json["error"] == "Max hackathon capacity has been reached"

--- a/services/py-api/tests/integration_tests/test_verification_routes.py
+++ b/services/py-api/tests/integration_tests/test_verification_routes.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 from httpx import AsyncClient
 import pytest
 from src.database.repository.teams_repository import TeamsRepository
-from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserVerification
+from src.server.schemas.jwt_schemas.schemas import JwtParticipantVerification
 from src.utils import JwtUtility
 from tests.integration_tests.conftest import CreateTestParticipantCallable, ParticipantRequestBodyCallable
 from tests.integration_tests.test_jwt_utility import sufficient_expiration_time
@@ -27,7 +27,7 @@ async def test_verify_random_participant_success(
     create_resp_json = create_resp.json()
 
     # Generate jwt token based on the random participant that was created
-    verify_jwt_token_payload = JwtUserVerification(
+    verify_jwt_token_payload = JwtParticipantVerification(
         sub=create_resp_json["participant"]["id"], is_admin=False, exp=sufficient_expiration_time
     )
     verify_jwt_token = JwtUtility.encode_data(data=verify_jwt_token_payload)
@@ -55,7 +55,9 @@ async def test_verify_random_participant_success(
 async def test_verify_random_participant_not_found(async_client: AsyncClient, mock_obj_id: str) -> None:
 
     # Generate jwt token based on a mock object id that does not exist on the database
-    verify_jwt_token_payload = JwtUserVerification(sub=mock_obj_id, is_admin=False, exp=sufficient_expiration_time)
+    verify_jwt_token_payload = JwtParticipantVerification(
+        sub=mock_obj_id, is_admin=False, exp=sufficient_expiration_time
+    )
     verify_jwt_token = JwtUtility.encode_data(data=verify_jwt_token_payload)
 
     # Make call to the endpoint to verify participant
@@ -97,7 +99,7 @@ async def test_verify_random_participant_hackathon_capacity_exceeded(
     # We try to verify each of them, but we should only be able to verify up to the capacity
     for i in range(TeamsRepository.MAX_NUMBER_OF_TEAM_MEMBERS + 1):
         # Generate jwt token based on a mock object id that does not exist on the database
-        verify_jwt_token_payload = JwtUserVerification(
+        verify_jwt_token_payload = JwtParticipantVerification(
             sub=created_participant_ids.pop(), is_admin=False, exp=sufficient_expiration_time
         )
         verify_jwt_token = JwtUtility.encode_data(data=verify_jwt_token_payload)

--- a/services/py-api/tests/unit_tests/conftest.py
+++ b/services/py-api/tests/unit_tests/conftest.py
@@ -13,7 +13,7 @@ from src.database.model.team_model import Team
 from src.database.repository.participants_repository import ParticipantsRepository
 from src.database.repository.teams_repository import TeamsRepository
 from src.database.transaction_manager import TransactionManager
-from src.server.schemas.jwt_schemas.schemas import JwtParticipantInviteRegistration, JwtParticipantVerification
+from src.server.schemas.jwt_schemas.schemas import JwtParticipantInviteRegistrationData, JwtParticipantVerificationData
 from src.server.schemas.request_schemas.schemas import (
     AdminParticipantInputData,
     InviteLinkParticipantInputData,
@@ -23,7 +23,6 @@ from src.server.schemas.request_schemas.schemas import (
 from src.service.hackathon_service import HackathonService
 from src.service.participants_registration_service import ParticipantRegistrationService
 from src.service.participants_verification_service import ParticipantVerificationService
-from tests.integration_tests.test_jwt_utility import sufficient_expiration_time
 from tests.integration_tests.conftest import TEST_USER_EMAIL, TEST_USER_NAME, TEST_TEAM_NAME
 
 
@@ -233,29 +232,35 @@ def mock_obj_id() -> str:
 
 
 @pytest.fixture
-def mock_jwt_user_registration(mock_obj_id: str) -> JwtParticipantInviteRegistration:
-    return JwtParticipantInviteRegistration(
+def mock_jwt_user_registration(
+    mock_obj_id: str, thirty_sec_jwt_exp_limit: float
+) -> JwtParticipantInviteRegistrationData:
+    return JwtParticipantInviteRegistrationData(
         sub=mock_obj_id,
         team_id=mock_obj_id,
-        exp=sufficient_expiration_time,
+        exp=thirty_sec_jwt_exp_limit,
     )
 
 
 @pytest.fixture
-def mock_jwt_random_user_verification(mock_obj_id: str) -> JwtParticipantVerification:
-    return JwtParticipantVerification(
+def mock_jwt_random_user_verification(
+    mock_obj_id: str, thirty_sec_jwt_exp_limit: float
+) -> JwtParticipantVerificationData:
+    return JwtParticipantVerificationData(
         sub=mock_obj_id,
         is_admin=False,
-        exp=sufficient_expiration_time,
+        exp=thirty_sec_jwt_exp_limit,
     )
 
 
 @pytest.fixture
-def mock_jwt_admin_user_verification(mock_obj_id: str) -> JwtParticipantVerification:
-    return JwtParticipantVerification(
+def mock_jwt_admin_user_verification(
+    mock_obj_id: str, thirty_sec_jwt_exp_limit: float
+) -> JwtParticipantVerificationData:
+    return JwtParticipantVerificationData(
         sub=mock_obj_id,
         is_admin=True,
-        exp=sufficient_expiration_time,
+        exp=thirty_sec_jwt_exp_limit,
     )
 
 

--- a/services/py-api/tests/unit_tests/conftest.py
+++ b/services/py-api/tests/unit_tests/conftest.py
@@ -13,7 +13,7 @@ from src.database.model.team_model import Team
 from src.database.repository.participants_repository import ParticipantsRepository
 from src.database.repository.teams_repository import TeamsRepository
 from src.database.transaction_manager import TransactionManager
-from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserRegistration
+from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserRegistration, JwtUserVerification
 from src.server.schemas.request_schemas.schemas import (
     AdminParticipantInputData,
     InviteLinkParticipantInputData,
@@ -22,6 +22,7 @@ from src.server.schemas.request_schemas.schemas import (
 )
 from src.service.hackathon_service import HackathonService
 from src.service.participants_registration_service import ParticipantRegistrationService
+from src.service.participants_verification_service import ParticipantVerificationService
 from tests.integration_tests.test_jwt_utility import sufficient_expiration_time
 from tests.integration_tests.conftest import TEST_USER_EMAIL, TEST_USER_NAME, TEST_TEAM_NAME
 
@@ -132,6 +133,15 @@ def participant_registration_service_mock() -> Mock:
 
 
 @pytest.fixture
+def participant_verification_service_mock() -> Mock:
+    """This is a mock obj of ParticipantVerificationService."""
+    p_verify_service = Mock(spec=ParticipantVerificationService)
+    p_verify_service.verify_random_participant.return_value = AsyncMock()
+
+    return p_verify_service
+
+
+@pytest.fixture
 def mock_participant_request_body_admin_case(mock_normal_team: Team) -> ParticipantRequestBody:
     return ParticipantRequestBody(
         registration_info=AdminParticipantInputData(
@@ -227,6 +237,24 @@ def mock_jwt_user_registration(mock_obj_id: str) -> JwtUserRegistration:
     return JwtUserRegistration(
         sub=mock_obj_id,
         team_id=mock_obj_id,
+        exp=sufficient_expiration_time,
+    )
+
+
+@pytest.fixture
+def mock_jwt_random_user_verification(mock_obj_id: str) -> JwtUserVerification:
+    return JwtUserVerification(
+        sub=mock_obj_id,
+        is_admin=False,
+        exp=sufficient_expiration_time,
+    )
+
+
+@pytest.fixture
+def mock_jwt_admin_user_verification(mock_obj_id: str) -> JwtUserVerification:
+    return JwtUserVerification(
+        sub=mock_obj_id,
+        is_admin=True,
         exp=sufficient_expiration_time,
     )
 

--- a/services/py-api/tests/unit_tests/conftest.py
+++ b/services/py-api/tests/unit_tests/conftest.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Tuple, Optional
 
 import pytest
@@ -268,3 +268,8 @@ def mock_jwt_admin_user_verification(
 def ten_sec_window() -> Tuple[datetime, datetime]:
     now = datetime.now()
     return now - timedelta(seconds=10), now + timedelta(seconds=10)
+
+
+@pytest.fixture
+def thirty_sec_jwt_exp_limit() -> float:
+    return (datetime.now(tz=timezone.utc) + timedelta(seconds=30)).timestamp()

--- a/services/py-api/tests/unit_tests/conftest.py
+++ b/services/py-api/tests/unit_tests/conftest.py
@@ -13,7 +13,7 @@ from src.database.model.team_model import Team
 from src.database.repository.participants_repository import ParticipantsRepository
 from src.database.repository.teams_repository import TeamsRepository
 from src.database.transaction_manager import TransactionManager
-from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserData
+from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserRegistration
 from src.server.schemas.request_schemas.schemas import (
     AdminParticipantInputData,
     InviteLinkParticipantInputData,
@@ -223,13 +223,10 @@ def mock_obj_id() -> str:
 
 
 @pytest.fixture
-def mock_jwt_user_data(mock_obj_id: str) -> JwtUserData:
-    return JwtUserData(
+def mock_jwt_user_registration(mock_obj_id: str) -> JwtUserRegistration:
+    return JwtUserRegistration(
         sub=mock_obj_id,
-        is_admin=False,
-        team_name=TEST_TEAM_NAME,
         team_id=mock_obj_id,
-        is_invite=True,
         exp=sufficient_expiration_time,
     )
 

--- a/services/py-api/tests/unit_tests/conftest.py
+++ b/services/py-api/tests/unit_tests/conftest.py
@@ -13,7 +13,7 @@ from src.database.model.team_model import Team
 from src.database.repository.participants_repository import ParticipantsRepository
 from src.database.repository.teams_repository import TeamsRepository
 from src.database.transaction_manager import TransactionManager
-from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserRegistration, JwtUserVerification
+from src.server.schemas.jwt_schemas.schemas import JwtParticipantInviteRegistration, JwtParticipantVerification
 from src.server.schemas.request_schemas.schemas import (
     AdminParticipantInputData,
     InviteLinkParticipantInputData,
@@ -233,8 +233,8 @@ def mock_obj_id() -> str:
 
 
 @pytest.fixture
-def mock_jwt_user_registration(mock_obj_id: str) -> JwtUserRegistration:
-    return JwtUserRegistration(
+def mock_jwt_user_registration(mock_obj_id: str) -> JwtParticipantInviteRegistration:
+    return JwtParticipantInviteRegistration(
         sub=mock_obj_id,
         team_id=mock_obj_id,
         exp=sufficient_expiration_time,
@@ -242,8 +242,8 @@ def mock_jwt_user_registration(mock_obj_id: str) -> JwtUserRegistration:
 
 
 @pytest.fixture
-def mock_jwt_random_user_verification(mock_obj_id: str) -> JwtUserVerification:
-    return JwtUserVerification(
+def mock_jwt_random_user_verification(mock_obj_id: str) -> JwtParticipantVerification:
+    return JwtParticipantVerification(
         sub=mock_obj_id,
         is_admin=False,
         exp=sufficient_expiration_time,
@@ -251,8 +251,8 @@ def mock_jwt_random_user_verification(mock_obj_id: str) -> JwtUserVerification:
 
 
 @pytest.fixture
-def mock_jwt_admin_user_verification(mock_obj_id: str) -> JwtUserVerification:
-    return JwtUserVerification(
+def mock_jwt_admin_user_verification(mock_obj_id: str) -> JwtParticipantVerification:
+    return JwtParticipantVerification(
         sub=mock_obj_id,
         is_admin=True,
         exp=sufficient_expiration_time,

--- a/services/py-api/tests/unit_tests/test_database_layer/test_team_repository.py
+++ b/services/py-api/tests/unit_tests/test_database_layer/test_team_repository.py
@@ -144,3 +144,39 @@ async def test_fetch_by_team_name_general_error(db_manager_mock: Mock, repo: Tea
 
     assert isinstance(result, Err)
     assert isinstance(result.err_value, Exception)
+
+
+@pytest.mark.asyncio
+async def test_fetch_by_id_successful(db_manager_mock: Mock, mock_obj_id: str, repo: TeamsRepository) -> None:
+    db_manager_mock.get_collection.return_value.find_one = AsyncMock(
+        return_value={"name": TEST_TEAM_NAME, "is_verified": False}
+    )
+
+    result = await repo.fetch_by_id(mock_obj_id)
+
+    assert isinstance(result, Ok)
+    assert isinstance(result.ok_value, Team)
+
+    assert result.ok_value.id == mock_obj_id
+    assert result.ok_value.name == TEST_TEAM_NAME
+    assert result.ok_value.is_verified == False
+
+
+@pytest.mark.asyncio
+async def test_fetch_by_id_team_not_found(db_manager_mock: Mock, repo: TeamsRepository, mock_obj_id: str) -> None:
+    db_manager_mock.get_collection.return_value.find_one = AsyncMock(return_value=None)
+
+    result = await repo.fetch_by_id(mock_obj_id)
+
+    assert isinstance(result, Err)
+    assert isinstance(result.err_value, TeamNotFoundError)
+
+
+@pytest.mark.asyncio
+async def test_fetch_by_id_general_error(db_manager_mock: Mock, repo: TeamsRepository, mock_obj_id: str) -> None:
+    db_manager_mock.get_collection.return_value.find_one = AsyncMock(return_value=Exception("Test Error"))
+
+    result = await repo.fetch_by_id(mock_obj_id)
+
+    assert isinstance(result, Err)
+    assert isinstance(result.err_value, Exception)

--- a/services/py-api/tests/unit_tests/test_handlers/test_verification_handlers.py
+++ b/services/py-api/tests/unit_tests/test_handlers/test_verification_handlers.py
@@ -1,0 +1,131 @@
+from unittest.mock import Mock, patch
+from bson import ObjectId
+import pytest
+from result import Err, Ok
+from src.database.model.participant_model import Participant
+from src.server.exception import HackathonCapacityExceededError, ParticipantNotFoundError
+from src.server.handlers.verification_handlers import VerificationHandlers
+from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserRegistration, JwtUserVerification
+from src.server.schemas.response_schemas.schemas import ErrResponse, ParticipantVerifiedResponse, Response
+from src.utils import JwtUtility
+from tests.integration_tests.conftest import TEST_USER_EMAIL, TEST_USER_NAME
+from starlette import status
+
+
+@pytest.fixture
+def verification_handlers(participant_verification_service_mock: Mock) -> VerificationHandlers:
+    return VerificationHandlers(participant_verification_service_mock)
+
+
+@patch.dict("os.environ", {"SECRET_KEY": "abcdefghijklmnopqrst"})
+@pytest.mark.asyncio
+async def test_verify_random_participant_case_success(
+    verification_handlers: VerificationHandlers,
+    participant_verification_service_mock: Mock,
+    mock_jwt_random_user_verification: JwtUserVerification,
+    mock_obj_id: str,
+) -> None:
+    # Mock successful result from `verify_random_participant`
+    participant_verification_service_mock.verify_random_participant.return_value = Ok(
+        (
+            Participant(
+                id=mock_obj_id,
+                name=TEST_USER_NAME,
+                email=TEST_USER_EMAIL,
+                is_admin=False,
+                email_verified=True,
+                team_id=ObjectId(),
+            ),
+            None,
+        )
+    )
+
+    jwt_token = JwtUtility.encode_data(data=mock_jwt_random_user_verification)
+
+    # Call the verification handler
+    resp = await verification_handlers.verify_participant(jwt_token=jwt_token)
+
+    # Check that `verify_random_participant` was awaited once with the expected input_data
+    participant_verification_service_mock.verify_random_participant.assert_awaited_once_with(
+        jwt_data=mock_jwt_random_user_verification
+    )
+
+    # Assert that the response is successful
+    assert isinstance(resp, Response)
+    assert isinstance(resp.response_model, ParticipantVerifiedResponse)
+    assert resp.response_model.participant.name == TEST_USER_NAME
+    assert resp.response_model.participant.email == TEST_USER_EMAIL
+    assert resp.response_model.participant.is_admin is False
+    assert resp.response_model.participant.email_verified is True
+    assert resp.response_model.team is None
+    assert resp.status_code == status.HTTP_200_OK
+
+
+@patch.dict("os.environ", {"SECRET_KEY": "abcdefghijklmnopqrst"})
+@pytest.mark.asyncio
+async def test_verify_random_participant_decode_error(
+    verification_handlers: VerificationHandlers,
+    mock_jwt_user_registration: JwtUserRegistration,
+) -> None:
+    # Create the token with the wrong schema
+    jwt_token = JwtUtility.encode_data(data=mock_jwt_user_registration)
+
+    # Call the verification handler
+    resp = await verification_handlers.verify_participant(jwt_token=jwt_token)
+
+    # Assert that the response is unsuccessful
+    assert isinstance(resp, Response)
+    assert isinstance(resp.response_model, ErrResponse)
+    assert resp.response_model.error == "The decoded token does not match the Jwt schema"
+
+
+@patch.dict("os.environ", {"SECRET_KEY": "abcdefghijklmnopqrst"})
+@pytest.mark.asyncio
+async def test_verify_random_participant_not_found(
+    verification_handlers: VerificationHandlers,
+    participant_verification_service_mock: Mock,
+    mock_jwt_random_user_verification: JwtUserVerification,
+) -> None:
+    # Mock unsuccessful result from `verify_random_participant`
+    participant_verification_service_mock.verify_random_participant.return_value = Err(ParticipantNotFoundError())
+
+    jwt_token = JwtUtility.encode_data(data=mock_jwt_random_user_verification)
+
+    # Call the verification handler
+    resp = await verification_handlers.verify_participant(jwt_token=jwt_token)
+
+    # Check that `verify_random_participant` was awaited once with the expected input_data
+    participant_verification_service_mock.verify_random_participant.assert_awaited_once_with(
+        jwt_data=mock_jwt_random_user_verification
+    )
+
+    # Assert that the response is unsuccessful
+    assert isinstance(resp, Response)
+    assert isinstance(resp.response_model, ErrResponse)
+    assert resp.response_model.error == "The specified participant was not found"
+
+
+@patch.dict("os.environ", {"SECRET_KEY": "abcdefghijklmnopqrst"})
+@pytest.mark.asyncio
+async def test_verify_random_hackathon_capacity_reached(
+    verification_handlers: VerificationHandlers,
+    participant_verification_service_mock: Mock,
+    mock_jwt_random_user_verification: JwtUserVerification,
+) -> None:
+    # Mock unsuccessful result from `verify_random_participant`
+    participant_verification_service_mock.verify_random_participant.return_value = Err(HackathonCapacityExceededError())
+
+    jwt_token = JwtUtility.encode_data(data=mock_jwt_random_user_verification)
+
+    # Call the verification handler
+    resp = await verification_handlers.verify_participant(jwt_token=jwt_token)
+
+    # Check that `verify_random_participant` was awaited once with the expected input_data
+    participant_verification_service_mock.verify_random_participant.assert_awaited_once_with(
+        jwt_data=mock_jwt_random_user_verification
+    )
+
+    # Assert that the response is unsuccessful
+    assert isinstance(resp, Response)
+    assert isinstance(resp.response_model, ErrResponse)
+    assert resp.response_model.error == "Max hackathon capacity has been reached"

--- a/services/py-api/tests/unit_tests/test_handlers/test_verification_handlers.py
+++ b/services/py-api/tests/unit_tests/test_handlers/test_verification_handlers.py
@@ -5,7 +5,7 @@ from result import Err, Ok
 from src.database.model.participant_model import Participant
 from src.server.exception import HackathonCapacityExceededError, ParticipantNotFoundError
 from src.server.handlers.verification_handlers import VerificationHandlers
-from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserRegistration, JwtUserVerification
+from src.server.schemas.jwt_schemas.schemas import JwtParticipantInviteRegistration, JwtParticipantVerification
 from src.server.schemas.response_schemas.schemas import ErrResponse, ParticipantVerifiedResponse, Response
 from src.utils import JwtUtility
 from tests.integration_tests.conftest import TEST_USER_EMAIL, TEST_USER_NAME
@@ -22,7 +22,7 @@ def verification_handlers(participant_verification_service_mock: Mock) -> Verifi
 async def test_verify_random_participant_case_success(
     verification_handlers: VerificationHandlers,
     participant_verification_service_mock: Mock,
-    mock_jwt_random_user_verification: JwtUserVerification,
+    mock_jwt_random_user_verification: JwtParticipantVerification,
     mock_obj_id: str,
 ) -> None:
     # Mock successful result from `verify_random_participant`
@@ -65,7 +65,7 @@ async def test_verify_random_participant_case_success(
 @pytest.mark.asyncio
 async def test_verify_random_participant_decode_error(
     verification_handlers: VerificationHandlers,
-    mock_jwt_user_registration: JwtUserRegistration,
+    mock_jwt_user_registration: JwtParticipantInviteRegistration,
 ) -> None:
     # Create the token with the wrong schema
     jwt_token = JwtUtility.encode_data(data=mock_jwt_user_registration)
@@ -84,7 +84,7 @@ async def test_verify_random_participant_decode_error(
 async def test_verify_random_participant_not_found(
     verification_handlers: VerificationHandlers,
     participant_verification_service_mock: Mock,
-    mock_jwt_random_user_verification: JwtUserVerification,
+    mock_jwt_random_user_verification: JwtParticipantVerification,
 ) -> None:
     # Mock unsuccessful result from `verify_random_participant`
     participant_verification_service_mock.verify_random_participant.return_value = Err(ParticipantNotFoundError())
@@ -110,7 +110,7 @@ async def test_verify_random_participant_not_found(
 async def test_verify_random_hackathon_capacity_reached(
     verification_handlers: VerificationHandlers,
     participant_verification_service_mock: Mock,
-    mock_jwt_random_user_verification: JwtUserVerification,
+    mock_jwt_random_user_verification: JwtParticipantVerification,
 ) -> None:
     # Mock unsuccessful result from `verify_random_participant`
     participant_verification_service_mock.verify_random_participant.return_value = Err(HackathonCapacityExceededError())

--- a/services/py-api/tests/unit_tests/test_handlers/test_verification_handlers.py
+++ b/services/py-api/tests/unit_tests/test_handlers/test_verification_handlers.py
@@ -5,7 +5,7 @@ from result import Err, Ok
 from src.database.model.participant_model import Participant
 from src.server.exception import HackathonCapacityExceededError, ParticipantNotFoundError
 from src.server.handlers.verification_handlers import VerificationHandlers
-from src.server.schemas.jwt_schemas.schemas import JwtParticipantInviteRegistration, JwtParticipantVerification
+from src.server.schemas.jwt_schemas.schemas import JwtParticipantInviteRegistrationData, JwtParticipantVerificationData
 from src.server.schemas.response_schemas.schemas import ErrResponse, ParticipantVerifiedResponse, Response
 from src.utils import JwtUtility
 from tests.integration_tests.conftest import TEST_USER_EMAIL, TEST_USER_NAME
@@ -22,7 +22,7 @@ def verification_handlers(participant_verification_service_mock: Mock) -> Verifi
 async def test_verify_random_participant_case_success(
     verification_handlers: VerificationHandlers,
     participant_verification_service_mock: Mock,
-    mock_jwt_random_user_verification: JwtParticipantVerification,
+    mock_jwt_random_user_verification: JwtParticipantVerificationData,
     mock_obj_id: str,
 ) -> None:
     # Mock successful result from `verify_random_participant`
@@ -65,7 +65,7 @@ async def test_verify_random_participant_case_success(
 @pytest.mark.asyncio
 async def test_verify_random_participant_decode_error(
     verification_handlers: VerificationHandlers,
-    mock_jwt_user_registration: JwtParticipantInviteRegistration,
+    mock_jwt_user_registration: JwtParticipantInviteRegistrationData,
 ) -> None:
     # Create the token with the wrong schema
     jwt_token = JwtUtility.encode_data(data=mock_jwt_user_registration)
@@ -84,7 +84,7 @@ async def test_verify_random_participant_decode_error(
 async def test_verify_random_participant_not_found(
     verification_handlers: VerificationHandlers,
     participant_verification_service_mock: Mock,
-    mock_jwt_random_user_verification: JwtParticipantVerification,
+    mock_jwt_random_user_verification: JwtParticipantVerificationData,
 ) -> None:
     # Mock unsuccessful result from `verify_random_participant`
     participant_verification_service_mock.verify_random_participant.return_value = Err(ParticipantNotFoundError())
@@ -110,7 +110,7 @@ async def test_verify_random_participant_not_found(
 async def test_verify_random_hackathon_capacity_reached(
     verification_handlers: VerificationHandlers,
     participant_verification_service_mock: Mock,
-    mock_jwt_random_user_verification: JwtParticipantVerification,
+    mock_jwt_random_user_verification: JwtParticipantVerificationData,
 ) -> None:
     # Mock unsuccessful result from `verify_random_participant`
     participant_verification_service_mock.verify_random_participant.return_value = Err(HackathonCapacityExceededError())

--- a/services/py-api/tests/unit_tests/test_service_layer/test_hackathon_service.py
+++ b/services/py-api/tests/unit_tests/test_service_layer/test_hackathon_service.py
@@ -7,7 +7,7 @@ from result import Ok, Err
 from src.database.model.participant_model import Participant
 from src.database.model.team_model import Team
 from src.server.exception import DuplicateTeamNameError, DuplicateEmailError, TeamNameMissmatchError, TeamNotFoundError
-from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserRegistration
+from src.server.schemas.jwt_schemas.schemas import JwtParticipantInviteRegistration
 from src.server.schemas.request_schemas.schemas import (
     AdminParticipantInputData,
     InviteLinkParticipantInputData,
@@ -284,7 +284,7 @@ async def test_create_link_participant_success(
     participant_repo_mock: Mock,
     team_repo_mock: Mock,
     mock_obj_id: str,
-    mock_jwt_user_registration: JwtUserRegistration,
+    mock_jwt_user_registration: JwtParticipantInviteRegistration,
 ) -> None:
 
     # Mock successful `fetch_by_id` response for link participant's team.
@@ -323,7 +323,7 @@ async def test_create_link_participant_team_not_found(
     hackathon_service: HackathonService,
     mock_invite_link_case_input_data: InviteLinkParticipantInputData,
     team_repo_mock: Mock,
-    mock_jwt_user_registration: JwtUserRegistration,
+    mock_jwt_user_registration: JwtParticipantInviteRegistration,
 ) -> None:
 
     # Mock TeamNotFoundError as `fetch_by_id` response for link participant's team.
@@ -343,7 +343,7 @@ async def test_create_link_participant_duplicate_email_error(
     mock_invite_link_case_input_data: InviteLinkParticipantInputData,
     participant_repo_mock: Mock,
     team_repo_mock: Mock,
-    mock_jwt_user_registration: JwtUserRegistration,
+    mock_jwt_user_registration: JwtParticipantInviteRegistration,
 ) -> None:
 
     # Mock successful `fetch_by_id` response for link participant's team.
@@ -369,7 +369,7 @@ async def test_register_link_participant_team_name_mismatch(
     hackathon_service: HackathonService,
     team_repo_mock: Mock,
     mock_invite_link_case_input_data: InviteLinkParticipantInputData,
-    mock_jwt_user_registration: JwtUserRegistration,
+    mock_jwt_user_registration: JwtParticipantInviteRegistration,
 ) -> None:
     # Modify the input_data to create a mismatch between the team names in the jwt and input data
     mock_invite_link_case_input_data.team_name = "modifiedteam"

--- a/services/py-api/tests/unit_tests/test_service_layer/test_hackathon_service.py
+++ b/services/py-api/tests/unit_tests/test_service_layer/test_hackathon_service.py
@@ -7,7 +7,7 @@ from result import Ok, Err
 from src.database.model.participant_model import Participant
 from src.database.model.team_model import Team
 from src.server.exception import DuplicateTeamNameError, DuplicateEmailError, TeamNameMissmatchError, TeamNotFoundError
-from src.server.schemas.jwt_schemas.schemas import JwtParticipantInviteRegistration
+from src.server.schemas.jwt_schemas.schemas import JwtParticipantInviteRegistrationData
 from src.server.schemas.request_schemas.schemas import (
     AdminParticipantInputData,
     InviteLinkParticipantInputData,
@@ -284,7 +284,7 @@ async def test_create_link_participant_success(
     participant_repo_mock: Mock,
     team_repo_mock: Mock,
     mock_obj_id: str,
-    mock_jwt_user_registration: JwtParticipantInviteRegistration,
+    mock_jwt_user_registration: JwtParticipantInviteRegistrationData,
 ) -> None:
 
     # Mock successful `fetch_by_id` response for link participant's team.
@@ -323,7 +323,7 @@ async def test_create_link_participant_team_not_found(
     hackathon_service: HackathonService,
     mock_invite_link_case_input_data: InviteLinkParticipantInputData,
     team_repo_mock: Mock,
-    mock_jwt_user_registration: JwtParticipantInviteRegistration,
+    mock_jwt_user_registration: JwtParticipantInviteRegistrationData,
 ) -> None:
 
     # Mock TeamNotFoundError as `fetch_by_id` response for link participant's team.
@@ -343,7 +343,7 @@ async def test_create_link_participant_duplicate_email_error(
     mock_invite_link_case_input_data: InviteLinkParticipantInputData,
     participant_repo_mock: Mock,
     team_repo_mock: Mock,
-    mock_jwt_user_registration: JwtParticipantInviteRegistration,
+    mock_jwt_user_registration: JwtParticipantInviteRegistrationData,
 ) -> None:
 
     # Mock successful `fetch_by_id` response for link participant's team.
@@ -369,7 +369,7 @@ async def test_register_link_participant_team_name_mismatch(
     hackathon_service: HackathonService,
     team_repo_mock: Mock,
     mock_invite_link_case_input_data: InviteLinkParticipantInputData,
-    mock_jwt_user_registration: JwtParticipantInviteRegistration,
+    mock_jwt_user_registration: JwtParticipantInviteRegistrationData,
 ) -> None:
     # Modify the input_data to create a mismatch between the team names in the jwt and input data
     mock_invite_link_case_input_data.team_name = "modifiedteam"

--- a/services/py-api/tests/unit_tests/test_service_layer/test_hackathon_service.py
+++ b/services/py-api/tests/unit_tests/test_service_layer/test_hackathon_service.py
@@ -6,14 +6,15 @@ from result import Ok, Err
 
 from src.database.model.participant_model import Participant
 from src.database.model.team_model import Team
-from src.server.exception import DuplicateTeamNameError, DuplicateEmailError, TeamNotFoundError
-from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserData
+from src.server.exception import DuplicateTeamNameError, DuplicateEmailError, TeamNameMissmatchError, TeamNotFoundError
+from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserRegistration
 from src.server.schemas.request_schemas.schemas import (
     AdminParticipantInputData,
     InviteLinkParticipantInputData,
     RandomParticipantInputData,
 )
 from src.service.hackathon_service import HackathonService
+from tests.integration_tests.conftest import TEST_TEAM_NAME
 
 
 @pytest.fixture
@@ -283,12 +284,12 @@ async def test_create_link_participant_success(
     participant_repo_mock: Mock,
     team_repo_mock: Mock,
     mock_obj_id: str,
-    mock_jwt_user_data: JwtUserData,
+    mock_jwt_user_registration: JwtUserRegistration,
 ) -> None:
 
-    # Mock successful `fetch_by_team_name` response for link participant's team.
-    team_repo_mock.fetch_by_team_name.return_value = Ok(
-        Team(id=ObjectId(mock_obj_id), name=mock_invite_link_case_input_data.team_name)
+    # Mock successful `fetch_by_id` response for link participant's team.
+    team_repo_mock.fetch_by_id.return_value = Ok(
+        Team(id=ObjectId(mock_jwt_user_registration["team_id"]), name=mock_invite_link_case_input_data.team_name)
     )
 
     # Mock successful `create` response for link participant.
@@ -303,7 +304,7 @@ async def test_create_link_participant_success(
     )
 
     result = await hackathon_service.create_invite_link_participant(
-        mock_invite_link_case_input_data, mock_jwt_user_data
+        mock_invite_link_case_input_data, mock_jwt_user_registration
     )
 
     # Validate that the result is an `Ok` instance containing the participant object
@@ -322,14 +323,14 @@ async def test_create_link_participant_team_not_found(
     hackathon_service: HackathonService,
     mock_invite_link_case_input_data: InviteLinkParticipantInputData,
     team_repo_mock: Mock,
-    mock_jwt_user_data: JwtUserData,
+    mock_jwt_user_registration: JwtUserRegistration,
 ) -> None:
 
-    # Mock TeamNotFoundError as `fetch_by_team_name` response for link participant's team.
-    team_repo_mock.fetch_by_team_name.return_value = Err(TeamNotFoundError())
+    # Mock TeamNotFoundError as `fetch_by_id` response for link participant's team.
+    team_repo_mock.fetch_by_id.return_value = Err(TeamNotFoundError())
 
     result = await hackathon_service.create_invite_link_participant(
-        mock_invite_link_case_input_data, mock_jwt_user_data
+        mock_invite_link_case_input_data, mock_jwt_user_registration
     )
 
     assert isinstance(result, Err)
@@ -342,26 +343,50 @@ async def test_create_link_participant_duplicate_email_error(
     mock_invite_link_case_input_data: InviteLinkParticipantInputData,
     participant_repo_mock: Mock,
     team_repo_mock: Mock,
-    mock_obj_id: str,
-    mock_jwt_user_data: JwtUserData,
+    mock_jwt_user_registration: JwtUserRegistration,
 ) -> None:
 
-    # Mock successful `fetch_by_team_name` response for link participant's team.
-    team_repo_mock.fetch_by_team_name.return_value = Ok(
-        Team(id=ObjectId(mock_obj_id), name=mock_invite_link_case_input_data.team_name)
+    # Mock successful `fetch_by_id` response for link participant's team.
+    team_repo_mock.fetch_by_id.return_value = Ok(
+        Team(id=ObjectId(mock_jwt_user_registration["team_id"]), name=mock_invite_link_case_input_data.team_name)
     )
 
     # Mock successful `create` response for link participant.
     participant_repo_mock.create.return_value = Err(DuplicateEmailError(mock_invite_link_case_input_data.email))
 
     result = await hackathon_service.create_invite_link_participant(
-        mock_invite_link_case_input_data, mock_jwt_user_data
+        mock_invite_link_case_input_data, mock_jwt_user_registration
     )
 
     # Check that the result is an `Err` with `DuplicateEmailError`
     assert isinstance(result, Err)
     assert isinstance(result.err_value, DuplicateEmailError)
     assert str(result.err_value) == mock_invite_link_case_input_data.email
+
+
+@pytest.mark.asyncio
+async def test_register_link_participant_team_name_mismatch(
+    hackathon_service: HackathonService,
+    team_repo_mock: Mock,
+    mock_invite_link_case_input_data: InviteLinkParticipantInputData,
+    mock_jwt_user_registration: JwtUserRegistration,
+) -> None:
+    # Modify the input_data to create a mismatch between the team names in the jwt and input data
+    mock_invite_link_case_input_data.team_name = "modifiedteam"
+
+    # Mock successful `fetch_by_id` response for link participant's team.
+    team_repo_mock.fetch_by_id.return_value = Ok(
+        Team(id=ObjectId(mock_jwt_user_registration["team_id"]), name=TEST_TEAM_NAME)
+    )
+
+    # Call the function under test
+    result = await hackathon_service.create_invite_link_participant(
+        mock_invite_link_case_input_data, mock_jwt_user_registration
+    )
+
+    # Check the err type
+    assert isinstance(result, Err)
+    assert isinstance(result.err_value, TeamNameMissmatchError)
 
 
 @pytest.mark.asyncio

--- a/services/py-api/tests/unit_tests/test_service_layer/test_participant_registration_service.py
+++ b/services/py-api/tests/unit_tests/test_service_layer/test_participant_registration_service.py
@@ -12,7 +12,7 @@ from src.server.exception import (
     HackathonCapacityExceededError,
     TeamCapacityExceededError,
 )
-from src.server.schemas.jwt_schemas.schemas import JwtParticipantInviteRegistration
+from src.server.schemas.jwt_schemas.schemas import JwtParticipantInviteRegistrationData
 from src.server.schemas.request_schemas.schemas import (
     AdminParticipantInputData,
     InviteLinkParticipantInputData,
@@ -322,7 +322,7 @@ async def test_register_link_participant_success(
     team_repo_mock: Mock,
     participant_repo_mock: Mock,
     mock_invite_link_case_input_data: InviteLinkParticipantInputData,
-    mock_jwt_user_registration: JwtParticipantInviteRegistration,
+    mock_jwt_user_registration: JwtParticipantInviteRegistrationData,
 ) -> None:
     # Mock team has available space
     hackathon_service_mock.check_team_capacity = AsyncMock(return_value=True)
@@ -363,7 +363,7 @@ async def test_register_link_participant_capacity_exceeded(
     p_reg_service: ParticipantRegistrationService,
     hackathon_service_mock: Mock,
     mock_invite_link_case_input_data: InviteLinkParticipantInputData,
-    mock_jwt_user_registration: JwtParticipantInviteRegistration,
+    mock_jwt_user_registration: JwtParticipantInviteRegistrationData,
 ) -> None:
     # Mock the check to return Team Capacity Exceeded Error
     hackathon_service_mock.check_team_capacity = AsyncMock(return_value=False)

--- a/services/py-api/tests/unit_tests/test_service_layer/test_participant_registration_service.py
+++ b/services/py-api/tests/unit_tests/test_service_layer/test_participant_registration_service.py
@@ -12,7 +12,7 @@ from src.server.exception import (
     HackathonCapacityExceededError,
     TeamCapacityExceededError,
 )
-from src.server.schemas.jwt_schemas.jwt_user_data_schema import JwtUserRegistration
+from src.server.schemas.jwt_schemas.schemas import JwtParticipantInviteRegistration
 from src.server.schemas.request_schemas.schemas import (
     AdminParticipantInputData,
     InviteLinkParticipantInputData,
@@ -322,7 +322,7 @@ async def test_register_link_participant_success(
     team_repo_mock: Mock,
     participant_repo_mock: Mock,
     mock_invite_link_case_input_data: InviteLinkParticipantInputData,
-    mock_jwt_user_registration: JwtUserRegistration,
+    mock_jwt_user_registration: JwtParticipantInviteRegistration,
 ) -> None:
     # Mock team has available space
     hackathon_service_mock.check_team_capacity = AsyncMock(return_value=True)
@@ -363,7 +363,7 @@ async def test_register_link_participant_capacity_exceeded(
     p_reg_service: ParticipantRegistrationService,
     hackathon_service_mock: Mock,
     mock_invite_link_case_input_data: InviteLinkParticipantInputData,
-    mock_jwt_user_registration: JwtUserRegistration,
+    mock_jwt_user_registration: JwtParticipantInviteRegistration,
 ) -> None:
     # Mock the check to return Team Capacity Exceeded Error
     hackathon_service_mock.check_team_capacity = AsyncMock(return_value=False)


### PR DESCRIPTION
#808 verify random participant flow

## Refactored the logic for verifying a participant:
@Alexandr-Ignatov did a great job implmenting the logic of the verification of the random participant. Due to structural changes that @IvanObreshkov and I did to the project, I had to do some refactoring and restructuring of things. 

Now we use a model to update the participant document called `UpdatedParticipant` which you can dump using `dump_model`. All the fields of this model are optional and `dump_model` will hide any field that is unset. This way you can use it to update the participant document using the method find_one_and_update().

We were previously relying on a single JWT schema that was inefficient because it included extra fields both in the verification and registration of the participant. I split the schema into 2 cases and updated the logic for adding a link participant and for verifying the random participant accordingly. 

resolves #808

## How to verify:

- [ ] Start the Api
- [ ] Create a random participant
- [ ] Verify the random participant
- [ ] Create an admin participant
- [ ] Generate a jwt token with the team_id that the admin created
- [ ] Register an invite_link participant to the team that was just created using the jwt token

