### PR TITLE
Switch db based on env

### DIFF
--- a/services/py-api/src/database/db_manager.py
+++ b/services/py-api/src/database/db_manager.py
@@ -19,7 +19,8 @@ class DatabaseManager(metaclass=SingletonMeta):
     pinging the database. The singleton behaviour allows us to have one instance of the AsyncIOMotorClient which we
     could safely use across our application through the interface of the DatabaseManager"""
 
-    _DB_NAME = "TheHubDEV"
+    # Set the database name based on the environment variable, defaulting to "TheHubDEV".
+    _DB_NAME = {"TEST": "TheHubTESTS", "PROD": "TheHubPROD"}.get(str(environ.get("ENV")), "TheHubDEV")
 
     def __init__(self) -> None:
         # The mongo client has a conn pool under the hood. We set a min number of idle connections that the pool has

--- a/services/py-api/src/database/db_manager.py
+++ b/services/py-api/src/database/db_manager.py
@@ -20,7 +20,8 @@ class DatabaseManager(metaclass=SingletonMeta):
     could safely use across our application through the interface of the DatabaseManager"""
 
     # Set the database name based on the environment variable, defaulting to "TheHubDEV".
-    _DB_NAME = {"TEST": "TheHubTESTS", "PROD": "TheHubPROD"}.get(str(environ.get("ENV")), "TheHubDEV")
+    # DEV and LOCAL environments are both using the same database `TheHubDEV`
+    _DB_NAME = {"TEST": "TheHubTESTS", "PROD": "TheHubPROD"}.get(str(environ["ENV"]), "TheHubDEV")
 
     def __init__(self) -> None:
         # The mongo client has a conn pool under the hood. We set a min number of idle connections that the pool has

--- a/services/py-api/tests/unit_tests/conftest.py
+++ b/services/py-api/tests/unit_tests/conftest.py
@@ -73,6 +73,7 @@ def participant_repo_mock() -> Mock:
     participant_repo.create = AsyncMock()
     participant_repo.delete = AsyncMock()
     participant_repo.get_number_registered_teammates = AsyncMock()
+    participant_repo.get_verified_random_participants_count = AsyncMock()
 
     return participant_repo
 
@@ -90,6 +91,7 @@ def team_repo_mock() -> Mock:
     team_repo.update = AsyncMock()
     team_repo.create = AsyncMock()
     team_repo.delete = AsyncMock()
+    team_repo.get_verified_registered_teams_count = AsyncMock()
 
     return team_repo
 
@@ -104,6 +106,11 @@ def hackathon_service_mock() -> Mock:
     hackathon_service.create_participant_and_team_in_transaction = AsyncMock()
     hackathon_service.check_capacity_register_admin_participant_case = AsyncMock()
     hackathon_service.check_capacity_register_random_participant_case = AsyncMock()
+    hackathon_service.create_random_participant = AsyncMock()
+    hackathon_service.create_invite_link_participant = AsyncMock()
+    hackathon_service.check_team_capacity = AsyncMock()
+    hackathon_service.verify_random_participant = AsyncMock()
+    hackathon_service.verify_admin_participant_and_team_in_transaction = AsyncMock()
     hackathon_service.delete_participant = AsyncMock()
     hackathon_service.delete_team = AsyncMock()
 
@@ -127,7 +134,9 @@ def participant_registration_service_mock() -> Mock:
     `p_reg_service.method_name.return_value=some_return_value`"""
 
     p_reg_service = Mock(spec=ParticipantRegistrationService)
-    p_reg_service.register_admin_participant.return_value = AsyncMock()
+    p_reg_service.register_admin_participant = AsyncMock()
+    p_reg_service.register_random_participant = AsyncMock()
+    p_reg_service.register_admin_participant = AsyncMock()
 
     return p_reg_service
 
@@ -136,7 +145,8 @@ def participant_registration_service_mock() -> Mock:
 def participant_verification_service_mock() -> Mock:
     """This is a mock obj of ParticipantVerificationService."""
     p_verify_service = Mock(spec=ParticipantVerificationService)
-    p_verify_service.verify_random_participant.return_value = AsyncMock()
+    p_verify_service.verify_random_participant = AsyncMock()
+    p_verify_service.verify_admin_participant = AsyncMock()
 
     return p_verify_service
 

--- a/services/py-api/tests/unit_tests/test_handlers/test_utility_handlers.py
+++ b/services/py-api/tests/unit_tests/test_handlers/test_utility_handlers.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, AsyncMock
+from unittest.mock import Mock
 
 import pytest
 from result import Err
@@ -10,7 +10,7 @@ from src.server.schemas.response_schemas.schemas import PongResponse, Response, 
 @pytest.mark.asyncio
 async def test_ping_handler(db_manager_mock: Mock) -> None:
     # Mock that async_ping_db return no error
-    db_manager_mock.async_ping_db = AsyncMock(return_value=None)
+    db_manager_mock.async_ping_db.return_value = None
     handler = UtilityHandlers(db_manager_mock)
 
     result = await handler.ping_services()
@@ -22,7 +22,7 @@ async def test_ping_handler(db_manager_mock: Mock) -> None:
 @pytest.mark.asyncio
 async def test_ping_handler_error(db_manager_mock: Mock) -> None:
     # Mock that async_ping_db return no error
-    db_manager_mock.async_ping_db = AsyncMock(return_value=Err("Test error"))
+    db_manager_mock.async_ping_db.return_value = Err("Test error")
     handler = UtilityHandlers(db_manager_mock)
 
     result = await handler.ping_services()

--- a/services/py-api/tests/unit_tests/test_service_layer/test_participant_registration_service.py
+++ b/services/py-api/tests/unit_tests/test_service_layer/test_participant_registration_service.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 from unittest.mock import Mock
 
 import pytest
@@ -36,7 +36,7 @@ async def test_register_admin_participant_success(
     mock_admin_case_input_data: AdminParticipantInputData,
 ) -> None:
     # Mock not full hackathon
-    hackathon_service_mock.check_capacity_register_admin_participant_case = AsyncMock(return_value=True)
+    hackathon_service_mock.check_capacity_register_admin_participant_case.return_value = True
 
     # Mock successful `create` responses for team and participant. These are the operations inside the passed callback
     # to with_transaction
@@ -69,7 +69,7 @@ async def test_register_admin_participant_duplicate_team_name_error(
     mock_admin_case_input_data: AdminParticipantInputData,
 ) -> None:
     # Mock not full hackathon
-    hackathon_service_mock.check_capacity_register_admin_participant_case = AsyncMock(return_value=True)
+    hackathon_service_mock.check_capacity_register_admin_participant_case.return_value = True
 
     # Mock `create_participant_and_team_in_transaction` to return an `Err` for duplicate team name
     hackathon_service_mock.create_participant_and_team_in_transaction.return_value = Err(
@@ -92,7 +92,7 @@ async def test_register_admin_participant_duplicate_email_error(
     mock_admin_case_input_data: AdminParticipantInputData,
 ) -> None:
     # Mock not full hackathon
-    hackathon_service_mock.check_capacity_register_admin_participant_case = AsyncMock(return_value=True)
+    hackathon_service_mock.check_capacity_register_admin_participant_case.return_value = True
 
     # Mock `create_participant_and_team_in_transaction` to return an `Err` for duplicate email err
     hackathon_service_mock.create_participant_and_team_in_transaction.return_value = Err(
@@ -115,7 +115,7 @@ async def test_register_admin_participant_general_error(
     mock_admin_case_input_data: AdminParticipantInputData,
 ) -> None:
     # Mock not full hackathon
-    hackathon_service_mock.check_capacity_register_admin_participant_case = AsyncMock(return_value=True)
+    hackathon_service_mock.check_capacity_register_admin_participant_case.return_value = True
 
     # Mock `create_participant_and_team_in_transaction` to raise a general exception
     hackathon_service_mock.create_participant_and_team_in_transaction.return_value = Err(Exception("Test error"))
@@ -138,7 +138,7 @@ async def test_register_admin_participant_with_hackathon_cap_exceeded(
     mock_admin_case_input_data: AdminParticipantInputData,
 ) -> None:
     # Mock full hackathon
-    hackathon_service_mock.check_capacity_register_admin_participant_case = AsyncMock(return_value=False)
+    hackathon_service_mock.check_capacity_register_admin_participant_case.return_value = False
 
     # Everything else is as expected
     team_repo_mock.create.return_value = Team(name=mock_admin_case_input_data.team_name)
@@ -168,7 +168,7 @@ async def test_register_admin_participant_order_of_operations(
     mock_admin_case_input_data: AdminParticipantInputData,
 ) -> None:
     # Mock full hackathon
-    hackathon_service_mock.check_capacity_register_admin_participant_case = AsyncMock(return_value=False)
+    hackathon_service_mock.check_capacity_register_admin_participant_case.return_value = False
 
     # Mock `create_participant_and_team_in_transaction` to raise a general exception
     # This is in order to show that we should return the first faced err and that we check first the hackathon capacity
@@ -191,7 +191,7 @@ async def test_register_random_participant_success(
     mock_random_case_input_data: RandomParticipantInputData,
 ) -> None:
     # Mock not full hackathon
-    hackathon_service_mock.check_capacity_register_random_participant_case = AsyncMock(return_value=True)
+    hackathon_service_mock.check_capacity_register_random_participant_case.return_value = True
 
     # Mock successful `create` responses for team and participant. These are the operations inside the passed callback
     # to with_transaction
@@ -227,7 +227,7 @@ async def test_register_random_participant_duplicate_email_error(
     mock_random_case_input_data: RandomParticipantInputData,
 ) -> None:
     # Mock not full hackathon
-    hackathon_service_mock.check_capacity_register_random_participant_case = AsyncMock(return_value=True)
+    hackathon_service_mock.check_capacity_register_random_participant_case.return_value = True
 
     # Mock `create_random_participant` to return an `Err` for duplicate email err
     hackathon_service_mock.create_random_participant.return_value = Err(
@@ -250,7 +250,7 @@ async def test_register_random_participant_general_error(
     mock_random_case_input_data: RandomParticipantInputData,
 ) -> None:
     # Mock not full hackathon
-    hackathon_service_mock.check_capacity_register_random_participant_case = AsyncMock(return_value=True)
+    hackathon_service_mock.check_capacity_register_random_participant_case.return_value = True
 
     # Mock `create_random_participant` to raise a general exception
     hackathon_service_mock.create_random_participant.return_value = Err(Exception("Test error"))
@@ -272,7 +272,7 @@ async def test_register_random_participant_with_hackathon_cap_exceeded(
     mock_random_case_input_data: RandomParticipantInputData,
 ) -> None:
     # Mock full hackathon
-    hackathon_service_mock.check_capacity_register_random_participant_case = AsyncMock(return_value=False)
+    hackathon_service_mock.check_capacity_register_random_participant_case.return_value = False
 
     # Everything else is as expected
     participant_repo_mock.create.return_value = Participant(
@@ -299,7 +299,7 @@ async def test_register_random_participant_order_of_operations(
     mock_random_case_input_data: RandomParticipantInputData,
 ) -> None:
     # Mock full hackathon
-    hackathon_service_mock.check_capacity_register_random_participant_case = AsyncMock(return_value=False)
+    hackathon_service_mock.check_capacity_register_random_participant_case.return_value = False
 
     # Mock `create_random_participant` to raise a general exception
     # This is in order to show that we should return the first faced err and that we check first the hackathon capacity
@@ -325,7 +325,7 @@ async def test_register_link_participant_success(
     mock_jwt_user_registration: JwtParticipantInviteRegistrationData,
 ) -> None:
     # Mock team has available space
-    hackathon_service_mock.check_team_capacity = AsyncMock(return_value=True)
+    hackathon_service_mock.check_team_capacity.return_value = True
 
     # Cereat a mock jwt_token to pass to the service method
     jwt_token = JwtUtility.encode_data(data=mock_jwt_user_registration)
@@ -366,7 +366,7 @@ async def test_register_link_participant_capacity_exceeded(
     mock_jwt_user_registration: JwtParticipantInviteRegistrationData,
 ) -> None:
     # Mock the check to return Team Capacity Exceeded Error
-    hackathon_service_mock.check_team_capacity = AsyncMock(return_value=False)
+    hackathon_service_mock.check_team_capacity.return_value = False
 
     # Cereat a mock jwt_token to pass to the service method
     jwt_token = JwtUtility.encode_data(data=mock_jwt_user_registration)


### PR DESCRIPTION
## Use a separate clean database for the testing environment:
We were having issues with integration tests not passing due to other existing documents on the DEV database that were clashing/interfering with the tests. To address this issue we created a separate TESTS database for the test environment. 

