### PR TITLE
922 Implements ellipses on hover and reworks the size dimensions for different devices

### DIFF
--- a/services/web/src/website/MainPage/MeetTheTeamSection/components/HubberModule.tsx
+++ b/services/web/src/website/MainPage/MeetTheTeamSection/components/HubberModule.tsx
@@ -5,12 +5,17 @@ type HubberModuleType = {
 
 export default function HubberModule({ imgSrc, name }: HubberModuleType) {
     return (
-        <div className="flex flex-col min-w-28 max-w-80 max-[1122px]:max-w-full h-70 p-2 border-[1px] rounded-[15px] border-[rgb(255,255,255,0.2)] font-semibold ">
-            <div className="h-5/6 w-full">
-                <img src={imgSrc} alt={name} className="object-cover w-full h-full rounded-xl" />
+        <div className="group flex flex-col min-w-28 max-w-80 max-[1122px]:max-w-full p-2 border border-[rgb(255,255,255,0.2)] rounded-[15px] font-semibold transition-all duration-300 hover:bg-transparent">
+            <div className="relative w-full">
+                <img src={imgSrc} alt={name} className="block w-full h-auto rounded-xl" />
             </div>
-            <div className="h-1/6 py-3 gap-2">
-                <h3 className="text-secondary">{name}</h3>
+            <div className="py-3 gap-2">
+                <h3
+                    className="text-secondary truncate w-full group-hover:whitespace-normal group-hover:overflow-visible"
+                    style={{ textOverflow: 'clip' }}
+                >
+                    {name}
+                </h3>
             </div>
         </div>
     );

--- a/services/web/src/website/MainPage/MeetTheTeamSection/components/HubberModule.tsx
+++ b/services/web/src/website/MainPage/MeetTheTeamSection/components/HubberModule.tsx
@@ -5,17 +5,12 @@ type HubberModuleType = {
 
 export default function HubberModule({ imgSrc, name }: HubberModuleType) {
     return (
-        <div className="group flex flex-col min-w-28 max-w-80 max-[1122px]:max-w-full p-2 border border-[rgb(255,255,255,0.2)] rounded-[15px] font-semibold transition-all duration-300 hover:bg-transparent">
-            <div className="relative w-full">
-                <img src={imgSrc} alt={name} className="block w-full h-auto rounded-xl" />
+        <div className="flex flex-col min-w-28 max-w-80 max-[1122px]:max-w-full h-70 p-2 border-[1px] rounded-[15px] border-[rgb(255,255,255,0.2)] font-semibold ">
+            <div className="h-5/6 w-full">
+                <img src={imgSrc} alt={name} className="object-cover w-full h-full rounded-xl" />
             </div>
-            <div className="py-3 gap-2">
-                <h3
-                    className="text-secondary truncate w-full group-hover:whitespace-normal group-hover:overflow-visible"
-                    style={{ textOverflow: 'clip' }}
-                >
-                    {name}
-                </h3>
+            <div className="h-1/6 py-3 gap-2">
+                <h3 className="text-secondary line-clamp-1">{name}</h3>
             </div>
         </div>
     );


### PR DESCRIPTION
#922 Implements ellipses on hover and reworks the size dimensions for different devices

## Added ellipses on hover effect for that one name:
Had to rework, the sizes of tiles and images, because otherwise it would either crop the image or would not display the full name on touch-screen devices.

Now it works on devices and it has an effect on hover

