### PR TITLE
954 Fix Registration Page Resending Email Issue

### DIFF
--- a/services/web/src/website/RegistrationFormPage/RegistrationForm/RegistrationForm.tsx
+++ b/services/web/src/website/RegistrationFormPage/RegistrationForm/RegistrationForm.tsx
@@ -126,6 +126,7 @@ export default function RegistrationForm() {
                 closeOnClick: true,
                 pauseOnHover: true,
                 draggable: true,
+                className: 'bg-[#000912] text-white',
             });
         }
     }, [data]);
@@ -150,6 +151,11 @@ export default function RegistrationForm() {
             registration_type: decodedToken?.team_name ? 'invite_link' : undefined,
             team_name: decodedToken?.team_name ?? '',
         },
+    });
+
+    const registrationType = useWatch({
+        control: form.control,
+        name: 'registration_type',
     });
 
     const onSubmit = (data: z.infer<typeof registrationSchema>) => {
@@ -182,6 +188,7 @@ export default function RegistrationForm() {
                 closeOnClick: true,
                 pauseOnHover: true,
                 draggable: true,
+                className: 'bg-[#000912] text-white',
             });
             return;
         }
@@ -200,6 +207,7 @@ export default function RegistrationForm() {
             closeOnClick: true,
             pauseOnHover: true,
             draggable: true,
+            className: 'bg-[#000912] text-white',
         });
     };
 
@@ -433,7 +441,7 @@ export default function RegistrationForm() {
                                     )}
                                 </Button>
                             </div>
-                            {data && (
+                            {data && registrationType !== 'invite_link' && (
                                 <p className="text-[#A6AAB2] mt-4 text-sm">
                                     Did not receive an email?{' '}
                                     <span


### PR DESCRIPTION
#954 Fix Registration Page Resending Email Issue

Updated Toast Styling and Resend Email Conditions

I adjusted the resend email functionality to only show when it's appropriate, not under the 'invite_link' registration type. I've also updated the toast notification styles to fit our dark theme better.

resolves #954 
